### PR TITLE
feat: 사장 매장 등록 API 구현

### DIFF
--- a/src/main/java/com/sparta/couponpop/domain/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/controller/StoreController.java
@@ -1,0 +1,26 @@
+package com.sparta.couponpop.domain.store.controller;
+
+import com.sparta.couponpop.common.response.ApiResponse;
+import com.sparta.couponpop.domain.store.dto.request.CreateStoreRequest;
+import com.sparta.couponpop.domain.store.dto.response.StoreResponse;
+import com.sparta.couponpop.domain.store.service.StoreService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/owner/stores")
+@RequiredArgsConstructor
+public class StoreController {
+
+    private final StoreService storeService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<StoreResponse>> createStore(@RequestBody @Valid CreateStoreRequest request) {
+
+        StoreResponse storeResponse = storeService.createStore(request);
+
+        return ApiResponse.success(storeResponse);
+    }
+}

--- a/src/main/java/com/sparta/couponpop/domain/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/controller/StoreController.java
@@ -19,7 +19,10 @@ public class StoreController {
     @PostMapping
     public ResponseEntity<ApiResponse<StoreResponse>> createStore(@RequestBody @Valid CreateStoreRequest request) {
 
-        StoreResponse storeResponse = storeService.createStore(request);
+        // TODO: 인증 구현 후 @LoginUserResolver로 memberId 가져오기
+        Long memberId = 1L; // 임시 memberId
+
+        StoreResponse storeResponse = storeService.createStore(memberId, request);
 
         return ApiResponse.success(storeResponse);
     }

--- a/src/main/java/com/sparta/couponpop/domain/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/controller/StoreController.java
@@ -24,6 +24,6 @@ public class StoreController {
 
         StoreResponse storeResponse = storeService.createStore(memberId, request);
 
-        return ApiResponse.success(storeResponse);
+        return ApiResponse.created(storeResponse);
     }
 }

--- a/src/main/java/com/sparta/couponpop/domain/store/dto/request/CreateStoreRequest.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/dto/request/CreateStoreRequest.java
@@ -1,0 +1,56 @@
+package com.sparta.couponpop.domain.store.dto.request;
+
+import com.sparta.couponpop.domain.store.enums.StoreCategory;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalTime;
+
+public record CreateStoreRequest(
+        @NotBlank(message = "매장명은 필수입니다")
+        @Size(max = 255, message = "매장명은 255자를 초과할 수 없습니다")
+        String name,
+
+        @NotBlank(message = "전화번호는 필수입니다")
+        @Pattern(regexp = "^\\d{11}$", message = "전화번호는 11자리 숫자여야 합니다")
+        String phone,
+
+        @Size(max = 500, message = "매장 설명은 500자를 초과할 수 없습니다")
+        String description,
+
+        @NotBlank(message = "사업자 번호는 필수입니다")
+        @Pattern(regexp = "^\\d{10}$", message = "사업자 번호는 10자리 숫자여야 합니다")
+        String businessNumber,
+
+        @NotBlank(message = "주소는 필수입니다")
+        @Size(max = 255, message = "주소는 255자를 초과할 수 없습니다")
+        String address,
+
+        @NotNull(message = "위도는 필수입니다")
+        Double latitude,
+
+        @NotNull(message = "경도는 필수입니다")
+        Double longitude,
+
+        @Size(max = 500, message = "이미지 URL은 500자를 초과할 수 없습니다")
+        String imageUrl,
+
+        @NotNull(message = "매장 카테고리는 필수입니다")
+        StoreCategory storeCategory,
+
+        @NotNull(message = "평일 오픈 시간은 필수입니다")
+        LocalTime weekdayOpenTime,
+
+        @NotNull(message = "평일 마감 시간은 필수입니다")
+        LocalTime weekdayCloseTime,
+
+        @NotNull(message = "주말 오픈 시간은 필수입니다")
+        LocalTime weekendOpenTime,
+
+        @NotNull(message = "주말 마감 시간은 필수입니다")
+        LocalTime weekendCloseTime
+) {
+}
+

--- a/src/main/java/com/sparta/couponpop/domain/store/dto/request/CreateStoreRequest.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/dto/request/CreateStoreRequest.java
@@ -17,6 +17,7 @@ public record CreateStoreRequest(
         @Pattern(regexp = "^\\d{11}$", message = "전화번호는 11자리 숫자여야 합니다")
         String phone,
 
+        @NotBlank(message = "매장 설명은 필수입니다")
         @Size(max = 500, message = "매장 설명은 500자를 초과할 수 없습니다")
         String description,
 

--- a/src/main/java/com/sparta/couponpop/domain/store/dto/response/StoreResponse.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/dto/response/StoreResponse.java
@@ -9,6 +9,7 @@ import java.time.LocalTime;
 public record StoreResponse(
         Long id,
         Long memberId,
+        String memberUsername,
         String name,
         String phone,
         String description,
@@ -29,7 +30,8 @@ public record StoreResponse(
     public static StoreResponse from(Store store) {
         return new StoreResponse(
                 store.getId(),
-                store.getMemberId(),
+                store.getMember().getId(),
+                store.getMember().getUsername(),
                 store.getName(),
                 store.getPhone(),
                 store.getDescription(),

--- a/src/main/java/com/sparta/couponpop/domain/store/dto/response/StoreResponse.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/dto/response/StoreResponse.java
@@ -8,6 +8,7 @@ import java.time.LocalTime;
 
 public record StoreResponse(
         Long id,
+        Long memberId,
         String name,
         String phone,
         String description,
@@ -28,6 +29,7 @@ public record StoreResponse(
     public static StoreResponse from(Store store) {
         return new StoreResponse(
                 store.getId(),
+                store.getMemberId(),
                 store.getName(),
                 store.getPhone(),
                 store.getDescription(),

--- a/src/main/java/com/sparta/couponpop/domain/store/dto/response/StoreResponse.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/dto/response/StoreResponse.java
@@ -1,0 +1,49 @@
+package com.sparta.couponpop.domain.store.dto.response;
+
+import com.sparta.couponpop.domain.store.entity.Store;
+import com.sparta.couponpop.domain.store.enums.StoreCategory;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public record StoreResponse(
+        Long id,
+        String name,
+        String phone,
+        String description,
+        String businessNumber,
+        String address,
+        Double latitude,
+        Double longitude,
+        String imageUrl,
+        StoreCategory storeCategory,
+        LocalTime weekdayOpenTime,
+        LocalTime weekdayCloseTime,
+        LocalTime weekendOpenTime,
+        LocalTime weekendCloseTime,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+
+    public static StoreResponse from(Store store) {
+        return new StoreResponse(
+                store.getId(),
+                store.getName(),
+                store.getPhone(),
+                store.getDescription(),
+                store.getBusinessNumber(),
+                store.getAddress(),
+                store.getLatitude(),
+                store.getLongitude(),
+                store.getImageUrl(),
+                store.getStoreCategory(),
+                store.getWeekdayOpenTime(),
+                store.getWeekdayCloseTime(),
+                store.getWeekendOpenTime(),
+                store.getWeekendCloseTime(),
+                store.getCreatedAt(),
+                store.getUpdatedAt()
+        );
+    }
+}
+

--- a/src/main/java/com/sparta/couponpop/domain/store/entity/Store.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/entity/Store.java
@@ -1,6 +1,7 @@
 package com.sparta.couponpop.domain.store.entity;
 
 import com.sparta.couponpop.common.entity.BaseEntity;
+import com.sparta.couponpop.domain.member.entity.Member;
 import com.sparta.couponpop.domain.store.enums.StoreCategory;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -21,32 +22,33 @@ public class Store extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "member_id", nullable = false)
-    private Long memberId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     @Column(name = "store_category", nullable = false)
     @Enumerated(EnumType.STRING)
     private StoreCategory storeCategory;
 
-    @Column(name = "name", nullable = false, length = 255)
+    @Column(nullable = false, length = 255)
     private String name;
 
-    @Column(name = "phone", nullable = false, length = 30)
+    @Column(nullable = false, length = 30)
     private String phone;
 
-    @Column(name = "description", nullable = false, columnDefinition = "TEXT")
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String description;
 
     @Column(name = "business_number", nullable = false, length = 30)
     private String businessNumber;
 
-    @Column(name = "address", nullable = false, length = 255)
+    @Column(nullable = false, length = 255)
     private String address;
 
-    @Column(name = "latitude", nullable = false)
+    @Column(nullable = false)
     private double latitude;
 
-    @Column(name = "longitude", nullable = false)
+    @Column(nullable = false)
     private double longitude;
 
     @Column(name = "image_url", nullable = false, length = 500)
@@ -68,11 +70,11 @@ public class Store extends BaseEntity {
     private LocalDateTime deletedAt;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private Store(Long memberId, String name, String phone, String description, String businessNumber,
+    private Store(Member member, String name, String phone, String description, String businessNumber,
                  String address, double latitude, double longitude, String imageUrl,
                  StoreCategory storeCategory, LocalTime weekdayOpenTime, LocalTime weekdayCloseTime,
                  LocalTime weekendOpenTime, LocalTime weekendCloseTime) {
-        this.memberId = memberId;
+        this.member = member;
         this.name = name;
         this.phone = phone;
         this.description = description;
@@ -88,7 +90,7 @@ public class Store extends BaseEntity {
         this.weekendCloseTime = weekendCloseTime;
     }
 
-    public static Store createStore(Long memberId,
+    public static Store createStore(Member member,
                                   String name,
                                   String phone,
                                   String description,
@@ -104,7 +106,7 @@ public class Store extends BaseEntity {
                                   LocalTime weekendCloseTime) {
 
         return Store.builder()
-                .memberId(memberId)
+                .member(member)
                 .name(name)
                 .phone(phone)
                 .description(description)

--- a/src/main/java/com/sparta/couponpop/domain/store/entity/Store.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/entity/Store.java
@@ -88,10 +88,21 @@ public class Store extends BaseEntity {
         this.weekendCloseTime = weekendCloseTime;
     }
 
-    public static Store createStore(Long memberId, String name, String phone, String description, String businessNumber,
-                                  String address, double latitude, double longitude, String imageUrl,
-                                  StoreCategory storeCategory, LocalTime weekdayOpenTime, LocalTime weekdayCloseTime,
-                                  LocalTime weekendOpenTime, LocalTime weekendCloseTime) {
+    public static Store createStore(Long memberId,
+                                  String name,
+                                  String phone,
+                                  String description,
+                                  String businessNumber,
+                                  String address,
+                                  double latitude,
+                                  double longitude,
+                                  String imageUrl,
+                                  StoreCategory storeCategory,
+                                  LocalTime weekdayOpenTime,
+                                  LocalTime weekdayCloseTime,
+                                  LocalTime weekendOpenTime,
+                                  LocalTime weekendCloseTime) {
+
         return Store.builder()
                 .memberId(memberId)
                 .name(name)

--- a/src/main/java/com/sparta/couponpop/domain/store/entity/Store.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/entity/Store.java
@@ -21,40 +21,58 @@ public class Store extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String name;
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
 
-    private String phone;
-
-    private String description;
-
-    private String businessNumber;
-
-    private String address;
-
-    private double latitude;
-
-    private double longitude;
-
-    private String imageUrl;
-
+    @Column(name = "store_category", nullable = false)
     @Enumerated(EnumType.STRING)
     private StoreCategory storeCategory;
 
+    @Column(name = "name", nullable = false, length = 255)
+    private String name;
+
+    @Column(name = "phone", nullable = false, length = 30)
+    private String phone;
+
+    @Column(name = "description", nullable = false, columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "business_number", nullable = false, length = 30)
+    private String businessNumber;
+
+    @Column(name = "address", nullable = false, length = 255)
+    private String address;
+
+    @Column(name = "latitude", nullable = false)
+    private double latitude;
+
+    @Column(name = "longitude", nullable = false)
+    private double longitude;
+
+    @Column(name = "image_url", nullable = false, length = 500)
+    private String imageUrl;
+
+    @Column(name = "weekday_open_time", nullable = false)
     private LocalTime weekdayOpenTime;
 
+    @Column(name = "weekday_close_time", nullable = false)
     private LocalTime weekdayCloseTime;
 
+    @Column(name = "weekend_open_time", nullable = false)
     private LocalTime weekendOpenTime;
 
+    @Column(name = "weekend_close_time", nullable = false)
     private LocalTime weekendCloseTime;
 
+    @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private Store(String name, String phone, String description, String businessNumber,
+    private Store(Long memberId, String name, String phone, String description, String businessNumber,
                  String address, double latitude, double longitude, String imageUrl,
                  StoreCategory storeCategory, LocalTime weekdayOpenTime, LocalTime weekdayCloseTime,
                  LocalTime weekendOpenTime, LocalTime weekendCloseTime) {
+        this.memberId = memberId;
         this.name = name;
         this.phone = phone;
         this.description = description;
@@ -70,11 +88,12 @@ public class Store extends BaseEntity {
         this.weekendCloseTime = weekendCloseTime;
     }
 
-    public static Store createStore(String name, String phone, String description, String businessNumber,
+    public static Store createStore(Long memberId, String name, String phone, String description, String businessNumber,
                                   String address, double latitude, double longitude, String imageUrl,
                                   StoreCategory storeCategory, LocalTime weekdayOpenTime, LocalTime weekdayCloseTime,
                                   LocalTime weekendOpenTime, LocalTime weekendCloseTime) {
         return Store.builder()
+                .memberId(memberId)
                 .name(name)
                 .phone(phone)
                 .description(description)

--- a/src/main/java/com/sparta/couponpop/domain/store/entity/Store.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/entity/Store.java
@@ -4,6 +4,7 @@ import com.sparta.couponpop.common.entity.BaseEntity;
 import com.sparta.couponpop.domain.store.enums.StoreCategory;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -48,4 +49,45 @@ public class Store extends BaseEntity {
     private LocalTime weekendCloseTime;
 
     private LocalDateTime deletedAt;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Store(String name, String phone, String description, String businessNumber,
+                 String address, double latitude, double longitude, String imageUrl,
+                 StoreCategory storeCategory, LocalTime weekdayOpenTime, LocalTime weekdayCloseTime,
+                 LocalTime weekendOpenTime, LocalTime weekendCloseTime) {
+        this.name = name;
+        this.phone = phone;
+        this.description = description;
+        this.businessNumber = businessNumber;
+        this.address = address;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.imageUrl = imageUrl;
+        this.storeCategory = storeCategory;
+        this.weekdayOpenTime = weekdayOpenTime;
+        this.weekdayCloseTime = weekdayCloseTime;
+        this.weekendOpenTime = weekendOpenTime;
+        this.weekendCloseTime = weekendCloseTime;
+    }
+
+    public static Store createStore(String name, String phone, String description, String businessNumber,
+                                  String address, double latitude, double longitude, String imageUrl,
+                                  StoreCategory storeCategory, LocalTime weekdayOpenTime, LocalTime weekdayCloseTime,
+                                  LocalTime weekendOpenTime, LocalTime weekendCloseTime) {
+        return Store.builder()
+                .name(name)
+                .phone(phone)
+                .description(description)
+                .businessNumber(businessNumber)
+                .address(address)
+                .latitude(latitude)
+                .longitude(longitude)
+                .imageUrl(imageUrl)
+                .storeCategory(storeCategory)
+                .weekdayOpenTime(weekdayOpenTime)
+                .weekdayCloseTime(weekdayCloseTime)
+                .weekendOpenTime(weekendOpenTime)
+                .weekendCloseTime(weekendCloseTime)
+                .build();
+    }
 }

--- a/src/main/java/com/sparta/couponpop/domain/store/exception/StoreErrorCode.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/exception/StoreErrorCode.java
@@ -1,0 +1,16 @@
+package com.sparta.couponpop.domain.store.exception;
+
+import com.sparta.couponpop.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum StoreErrorCode implements ErrorCode {
+
+    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 회원입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/sparta/couponpop/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/repository/StoreRepository.java
@@ -1,0 +1,8 @@
+package com.sparta.couponpop.domain.store.repository;
+
+import com.sparta.couponpop.domain.store.entity.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreRepository extends JpaRepository<Store, Long> {
+}
+

--- a/src/main/java/com/sparta/couponpop/domain/store/service/StoreService.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/service/StoreService.java
@@ -15,9 +15,10 @@ public class StoreService {
     private final StoreRepository storeRepository;
 
     @Transactional
-    public StoreResponse createStore(CreateStoreRequest request) {
+    public StoreResponse createStore(Long memberId, CreateStoreRequest request) {
 
         Store store = Store.createStore(
+                memberId,
                 request.name(),
                 request.phone(),
                 request.description(),

--- a/src/main/java/com/sparta/couponpop/domain/store/service/StoreService.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/service/StoreService.java
@@ -1,0 +1,40 @@
+package com.sparta.couponpop.domain.store.service;
+
+import com.sparta.couponpop.domain.store.dto.request.CreateStoreRequest;
+import com.sparta.couponpop.domain.store.dto.response.StoreResponse;
+import com.sparta.couponpop.domain.store.entity.Store;
+import com.sparta.couponpop.domain.store.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class StoreService {
+
+    private final StoreRepository storeRepository;
+
+    @Transactional
+    public StoreResponse createStore(CreateStoreRequest request) {
+
+        Store store = Store.createStore(
+                request.name(),
+                request.phone(),
+                request.description(),
+                request.businessNumber(),
+                request.address(),
+                request.latitude(),
+                request.longitude(),
+                request.imageUrl(),
+                request.storeCategory(),
+                request.weekdayOpenTime(),
+                request.weekdayCloseTime(),
+                request.weekendOpenTime(),
+                request.weekendCloseTime()
+        );
+
+        Store savedStore = storeRepository.save(store);
+
+        return StoreResponse.from(savedStore);
+    }
+}

--- a/src/main/java/com/sparta/couponpop/domain/store/service/StoreService.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/service/StoreService.java
@@ -1,8 +1,12 @@
 package com.sparta.couponpop.domain.store.service;
 
+import com.sparta.couponpop.common.exception.GlobalException;
+import com.sparta.couponpop.domain.member.entity.Member;
+import com.sparta.couponpop.domain.member.repository.MemberRepository;
 import com.sparta.couponpop.domain.store.dto.request.CreateStoreRequest;
 import com.sparta.couponpop.domain.store.dto.response.StoreResponse;
 import com.sparta.couponpop.domain.store.entity.Store;
+import com.sparta.couponpop.domain.store.exception.StoreErrorCode;
 import com.sparta.couponpop.domain.store.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,12 +17,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class StoreService {
 
     private final StoreRepository storeRepository;
+    private final MemberRepository memberRepository;
 
     @Transactional
     public StoreResponse createStore(Long memberId, CreateStoreRequest request) {
 
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GlobalException(StoreErrorCode.MEMBER_NOT_FOUND));
+
         Store store = Store.createStore(
-                memberId,
+                member,
                 request.name(),
                 request.phone(),
                 request.description(),

--- a/src/main/resources/db/migration/V3__add_columns_to_stores_table.sql
+++ b/src/main/resources/db/migration/V3__add_columns_to_stores_table.sql
@@ -1,0 +1,18 @@
+ALTER TABLE stores
+    ADD COLUMN member_id           BIGINT                NOT NULL COMMENT '매장 소유자 ID',
+    ADD COLUMN store_category      ENUM('CAFE', 'FOOD')  NOT NULL COMMENT '매장 카테고리',
+    ADD COLUMN name                VARCHAR(255)          NOT NULL COMMENT '매장명',
+    ADD COLUMN phone               VARCHAR(30)           NOT NULL COMMENT '매장 전화번호',
+    ADD COLUMN description         TEXT                  NOT NULL COMMENT '매장 설명',
+    ADD COLUMN business_number     VARCHAR(30)           NOT NULL COMMENT '사업자 번호',
+    ADD COLUMN address             VARCHAR(255)          NOT NULL COMMENT '매장 주소',
+    ADD COLUMN latitude            DOUBLE                NOT NULL COMMENT '위도',
+    ADD COLUMN longitude           DOUBLE                NOT NULL COMMENT '경도',
+    ADD COLUMN image_url           VARCHAR(500)          NOT NULL COMMENT '매장 이미지 URL',
+    ADD COLUMN weekday_open_time   TIME                  NOT NULL COMMENT '평일 오픈 시간',
+    ADD COLUMN weekday_close_time  TIME                  NOT NULL COMMENT '평일 마감 시간',
+    ADD COLUMN weekend_open_time   TIME                  NOT NULL COMMENT '주말 오픈 시간',
+    ADD COLUMN weekend_close_time  TIME                  NOT NULL COMMENT '주말 마감 시간',
+    ADD COLUMN created_at          DATETIME              NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성일',
+    ADD COLUMN updated_at          DATETIME              NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일',
+    ADD COLUMN deleted_at          DATETIME              NULL COMMENT '삭제일';

--- a/src/test/java/com/sparta/couponpop/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/store/service/StoreServiceTest.java
@@ -108,15 +108,15 @@ class StoreServiceTest {
     }
 
     @Test
-    @DisplayName("매장 등록 시 null 값 처리")
-    void createStore_WithNullDescription_Success() {
+    @DisplayName("매장 등록 시 빈 문자열 description 처리")
+    void createStore_WithEmptyDescription_Success() {
 
         // given
         Long memberId = 4L;
         CreateStoreRequest request = new CreateStoreRequest(
                 "테스트 매장",
                 "0212345678",
-                null, // description이 null
+                "", // description이 빈 문자열
                 "1234567890",
                 "서울시 테스트구 테스트로 123",
                 37.5665,
@@ -133,7 +133,7 @@ class StoreServiceTest {
                 memberId,
                 "테스트 매장",
                 "0212345678",
-                null,
+                "",
                 "1234567890",
                 "서울시 테스트구 테스트로 123",
                 37.5665,
@@ -153,7 +153,7 @@ class StoreServiceTest {
         StoreResponse result = storeService.createStore(memberId, request);
 
         // then
-        assertThat(result.description()).isNull();
+        assertThat(result.description()).isEmpty();
         assertThat(result.name()).isEqualTo("테스트 매장");
 
         then(storeRepository).should(times(1)).save(any(Store.class));

--- a/src/test/java/com/sparta/couponpop/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/store/service/StoreServiceTest.java
@@ -1,5 +1,8 @@
 package com.sparta.couponpop.domain.store.service;
 
+import com.sparta.couponpop.domain.member.entity.Member;
+import com.sparta.couponpop.domain.member.enums.MemberType;
+import com.sparta.couponpop.domain.member.repository.MemberRepository;
 import com.sparta.couponpop.domain.store.dto.request.CreateStoreRequest;
 import com.sparta.couponpop.domain.store.dto.response.StoreResponse;
 import com.sparta.couponpop.domain.store.entity.Store;
@@ -13,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalTime;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -27,6 +31,9 @@ class StoreServiceTest {
     @Mock
     private StoreRepository storeRepository;
 
+    @Mock
+    private MemberRepository memberRepository;
+
     @InjectMocks
     private StoreService storeService;
 
@@ -37,8 +44,11 @@ class StoreServiceTest {
         // given
         Long memberId = 1L;
         CreateStoreRequest request = createStoreRequest();
-        Store savedStore = createStore(memberId);
+        Member member = createMember(memberId);
+        Store savedStore = createStore(member);
 
+        given(memberRepository.findById(memberId))
+                .willReturn(Optional.of(member));
         given(storeRepository.save(any(Store.class)))
                 .willReturn(savedStore);
 
@@ -48,6 +58,7 @@ class StoreServiceTest {
         // then
         assertThat(result.id()).isEqualTo(savedStore.getId());
         assertThat(result.memberId()).isEqualTo(memberId);
+        assertThat(result.memberUsername()).isEqualTo(member.getUsername());
         assertThat(result.name()).isEqualTo(request.name());
         assertThat(result.phone()).isEqualTo(request.phone());
         assertThat(result.description()).isEqualTo(request.description());
@@ -62,6 +73,7 @@ class StoreServiceTest {
         assertThat(result.weekendOpenTime()).isEqualTo(request.weekendOpenTime());
         assertThat(result.weekendCloseTime()).isEqualTo(request.weekendCloseTime());
 
+        then(memberRepository).should(times(1)).findById(memberId);
         then(storeRepository).should(times(1)).save(any(Store.class));
     }
 
@@ -72,8 +84,11 @@ class StoreServiceTest {
         // given
         Long memberId = 2L;
         CreateStoreRequest request = createStoreRequest();
-        Store expectedStore = createStore(memberId);
+        Member member = createMember(memberId);
+        Store expectedStore = createStore(member);
 
+        given(memberRepository.findById(memberId))
+                .willReturn(Optional.of(member));
         given(storeRepository.save(any(Store.class)))
                 .willReturn(expectedStore);
 
@@ -81,6 +96,7 @@ class StoreServiceTest {
         storeService.createStore(memberId, request);
 
         // then
+        then(memberRepository).should(times(1)).findById(memberId);
         then(storeRepository).should(times(1)).save(any(Store.class));
     }
 
@@ -91,8 +107,11 @@ class StoreServiceTest {
         // given
         Long memberId = 3L;
         CreateStoreRequest request = createFoodStoreRequest();
-        Store savedStore = createFoodStore(memberId);
+        Member member = createMember(memberId);
+        Store savedStore = createFoodStore(member);
 
+        given(memberRepository.findById(memberId))
+                .willReturn(Optional.of(member));
         given(storeRepository.save(any(Store.class)))
                 .willReturn(savedStore);
 
@@ -104,6 +123,7 @@ class StoreServiceTest {
         assertThat(result.name()).isEqualTo("맛있는 식당");
         assertThat(result.memberId()).isEqualTo(memberId);
 
+        then(memberRepository).should(times(1)).findById(memberId);
         then(storeRepository).should(times(1)).save(any(Store.class));
     }
 
@@ -129,8 +149,9 @@ class StoreServiceTest {
                 LocalTime.of(22, 0)
         );
 
+        Member member = createMember(memberId);
         Store savedStore = Store.createStore(
-                memberId,
+                member,
                 "테스트 매장",
                 "0212345678",
                 "",
@@ -146,6 +167,8 @@ class StoreServiceTest {
                 LocalTime.of(22, 0)
         );
 
+        given(memberRepository.findById(memberId))
+                .willReturn(Optional.of(member));
         given(storeRepository.save(any(Store.class)))
                 .willReturn(savedStore);
 
@@ -156,6 +179,7 @@ class StoreServiceTest {
         assertThat(result.description()).isEmpty();
         assertThat(result.name()).isEqualTo("테스트 매장");
 
+        then(memberRepository).should(times(1)).findById(memberId);
         then(storeRepository).should(times(1)).save(any(Store.class));
     }
 
@@ -195,9 +219,28 @@ class StoreServiceTest {
         );
     }
 
-    private Store createStore(Long memberId) {
+    private Member createMember(Long memberId) {
+        Member member = Member.signUp(
+                "test@example.com",
+                "testuser",
+                "encodedPassword",
+                "01012345678",
+                MemberType.OWNER
+        );
+        // 테스트를 위해 ID를 설정하기 위해 리플렉션 사용
+        try {
+            var idField = Member.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(member, memberId);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set member ID", e);
+        }
+        return member;
+    }
+
+    private Store createStore(Member member) {
         return Store.createStore(
-                memberId,
+                member,
                 "스타벅스 홍대점",
                 "0212345678",
                 "홍대 중심가에 위치한 스타벅스입니다.",
@@ -214,9 +257,9 @@ class StoreServiceTest {
         );
     }
 
-    private Store createFoodStore(Long memberId) {
+    private Store createFoodStore(Member member) {
         return Store.createStore(
-                memberId,
+                member,
                 "맛있는 식당",
                 "0312345678",
                 "정말 맛있는 음식을 제공하는 식당입니다.",

--- a/src/test/java/com/sparta/couponpop/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/store/service/StoreServiceTest.java
@@ -1,0 +1,235 @@
+package com.sparta.couponpop.domain.store.service;
+
+import com.sparta.couponpop.domain.store.dto.request.CreateStoreRequest;
+import com.sparta.couponpop.domain.store.dto.response.StoreResponse;
+import com.sparta.couponpop.domain.store.entity.Store;
+import com.sparta.couponpop.domain.store.enums.StoreCategory;
+import com.sparta.couponpop.domain.store.repository.StoreRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("StoreService 테스트")
+class StoreServiceTest {
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @InjectMocks
+    private StoreService storeService;
+
+    @Test
+    @DisplayName("매장 등록 성공")
+    void createStore_Success() {
+
+        // given
+        Long memberId = 1L;
+        CreateStoreRequest request = createStoreRequest();
+        Store savedStore = createStore(memberId);
+
+        given(storeRepository.save(any(Store.class)))
+                .willReturn(savedStore);
+
+        // when
+        StoreResponse result = storeService.createStore(memberId, request);
+
+        // then
+        assertThat(result.id()).isEqualTo(savedStore.getId());
+        assertThat(result.memberId()).isEqualTo(memberId);
+        assertThat(result.name()).isEqualTo(request.name());
+        assertThat(result.phone()).isEqualTo(request.phone());
+        assertThat(result.description()).isEqualTo(request.description());
+        assertThat(result.businessNumber()).isEqualTo(request.businessNumber());
+        assertThat(result.address()).isEqualTo(request.address());
+        assertThat(result.latitude()).isEqualTo(request.latitude());
+        assertThat(result.longitude()).isEqualTo(request.longitude());
+        assertThat(result.imageUrl()).isEqualTo(request.imageUrl());
+        assertThat(result.storeCategory()).isEqualTo(request.storeCategory());
+        assertThat(result.weekdayOpenTime()).isEqualTo(request.weekdayOpenTime());
+        assertThat(result.weekdayCloseTime()).isEqualTo(request.weekdayCloseTime());
+        assertThat(result.weekendOpenTime()).isEqualTo(request.weekendOpenTime());
+        assertThat(result.weekendCloseTime()).isEqualTo(request.weekendCloseTime());
+
+        then(storeRepository).should(times(1)).save(any(Store.class));
+    }
+
+    @Test
+    @DisplayName("매장 등록 시 정확한 데이터로 Store 엔티티 생성")
+    void createStore_CreatesStoreWithCorrectData() {
+
+        // given
+        Long memberId = 2L;
+        CreateStoreRequest request = createStoreRequest();
+        Store expectedStore = createStore(memberId);
+
+        given(storeRepository.save(any(Store.class)))
+                .willReturn(expectedStore);
+
+        // when
+        storeService.createStore(memberId, request);
+
+        // then
+        then(storeRepository).should(times(1)).save(any(Store.class));
+    }
+
+    @Test
+    @DisplayName("다른 카테고리 매장 등록 성공")
+    void createStore_WithFoodCategory_Success() {
+
+        // given
+        Long memberId = 3L;
+        CreateStoreRequest request = createFoodStoreRequest();
+        Store savedStore = createFoodStore(memberId);
+
+        given(storeRepository.save(any(Store.class)))
+                .willReturn(savedStore);
+
+        // when
+        StoreResponse result = storeService.createStore(memberId, request);
+
+        // then
+        assertThat(result.storeCategory()).isEqualTo(StoreCategory.FOOD);
+        assertThat(result.name()).isEqualTo("맛있는 식당");
+        assertThat(result.memberId()).isEqualTo(memberId);
+
+        then(storeRepository).should(times(1)).save(any(Store.class));
+    }
+
+    @Test
+    @DisplayName("매장 등록 시 null 값 처리")
+    void createStore_WithNullDescription_Success() {
+
+        // given
+        Long memberId = 4L;
+        CreateStoreRequest request = new CreateStoreRequest(
+                "테스트 매장",
+                "0212345678",
+                null, // description이 null
+                "1234567890",
+                "서울시 테스트구 테스트로 123",
+                37.5665,
+                126.9780,
+                "https://example.com/test-image.jpg",
+                StoreCategory.CAFE,
+                LocalTime.of(9, 0),
+                LocalTime.of(21, 0),
+                LocalTime.of(10, 0),
+                LocalTime.of(22, 0)
+        );
+
+        Store savedStore = Store.createStore(
+                memberId,
+                "테스트 매장",
+                "0212345678",
+                null,
+                "1234567890",
+                "서울시 테스트구 테스트로 123",
+                37.5665,
+                126.9780,
+                "https://example.com/test-image.jpg",
+                StoreCategory.CAFE,
+                LocalTime.of(9, 0),
+                LocalTime.of(21, 0),
+                LocalTime.of(10, 0),
+                LocalTime.of(22, 0)
+        );
+
+        given(storeRepository.save(any(Store.class)))
+                .willReturn(savedStore);
+
+        // when
+        StoreResponse result = storeService.createStore(memberId, request);
+
+        // then
+        assertThat(result.description()).isNull();
+        assertThat(result.name()).isEqualTo("테스트 매장");
+
+        then(storeRepository).should(times(1)).save(any(Store.class));
+    }
+
+    private CreateStoreRequest createStoreRequest() {
+        return new CreateStoreRequest(
+                "스타벅스 홍대점",
+                "0212345678",
+                "홍대 중심가에 위치한 스타벅스입니다.",
+                "1234567890",
+                "서울시 마포구 홍익로 123",
+                37.5665,
+                126.9780,
+                "https://example.com/store-image.jpg",
+                StoreCategory.CAFE,
+                LocalTime.of(7, 0),
+                LocalTime.of(22, 0),
+                LocalTime.of(8, 0),
+                LocalTime.of(23, 0)
+        );
+    }
+
+    private CreateStoreRequest createFoodStoreRequest() {
+        return new CreateStoreRequest(
+                "맛있는 식당",
+                "0312345678",
+                "정말 맛있는 음식을 제공하는 식당입니다.",
+                "9876543210",
+                "서울시 강남구 테헤란로 456",
+                37.5665,
+                126.9780,
+                "https://example.com/food-store-image.jpg",
+                StoreCategory.FOOD,
+                LocalTime.of(11, 0),
+                LocalTime.of(22, 0),
+                LocalTime.of(12, 0),
+                LocalTime.of(23, 0)
+        );
+    }
+
+    private Store createStore(Long memberId) {
+        return Store.createStore(
+                memberId,
+                "스타벅스 홍대점",
+                "0212345678",
+                "홍대 중심가에 위치한 스타벅스입니다.",
+                "1234567890",
+                "서울시 마포구 홍익로 123",
+                37.5665,
+                126.9780,
+                "https://example.com/store-image.jpg",
+                StoreCategory.CAFE,
+                LocalTime.of(7, 0),
+                LocalTime.of(22, 0),
+                LocalTime.of(8, 0),
+                LocalTime.of(23, 0)
+        );
+    }
+
+    private Store createFoodStore(Long memberId) {
+        return Store.createStore(
+                memberId,
+                "맛있는 식당",
+                "0312345678",
+                "정말 맛있는 음식을 제공하는 식당입니다.",
+                "9876543210",
+                "서울시 강남구 테헤란로 456",
+                37.5665,
+                126.9780,
+                "https://example.com/food-store-image.jpg",
+                StoreCategory.FOOD,
+                LocalTime.of(11, 0),
+                LocalTime.of(22, 0),
+                LocalTime.of(12, 0),
+                LocalTime.of(23, 0)
+        );
+    }
+}


### PR DESCRIPTION
## 🔗 **연관된 이슈**
> close #이슈번호

Closes #14
<br>

## 📝 **작업 내용**

1. Store 엔티티 개선
- @Column 어노테이션 추가
- memberId 필드 추가 (매장-사장 연관관계)
- 정적 팩토리 메서드 createStore() 추가
- Builder 패턴으로 외부 생성 제한

2. DTO 클래스 생성
- CreateStoreRequest 생성 
- StoreResponse 생성

3. Repository & Service & Controller 추가

4. 테스트코드 
- StoreServiceTest: 4개 테스트 케이스
5. Store 에 대한 스키마 db/migration에 작성
<br>

## 📸 **스크린샷 (선택)**

<br>
