### PR TITLE
feat: 사장 매장 정보 수정 API 구현

### DIFF
--- a/src/main/java/com/sparta/couponpop/domain/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/controller/StoreController.java
@@ -28,8 +28,7 @@ public class StoreController {
     }
 
     @PutMapping("/{storeId}")
-    public ResponseEntity<ApiResponse<StoreResponse>> updateStore(@PathVariable Long storeId,
-                                                                @RequestBody @Valid CreateStoreRequest request) {
+    public ResponseEntity<ApiResponse<StoreResponse>> updateStore(@PathVariable Long storeId, @RequestBody @Valid CreateStoreRequest request) {
 
         // TODO: 인증 구현 후 @LoginUserResolver로 memberId 가져오기
         Long memberId = 1L; // 임시 memberId

--- a/src/main/java/com/sparta/couponpop/domain/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/controller/StoreController.java
@@ -26,4 +26,16 @@ public class StoreController {
 
         return ApiResponse.created(storeResponse);
     }
+
+    @PutMapping("/{storeId}")
+    public ResponseEntity<ApiResponse<StoreResponse>> updateStore(@PathVariable Long storeId,
+                                                                @RequestBody @Valid CreateStoreRequest request) {
+
+        // TODO: 인증 구현 후 @LoginUserResolver로 memberId 가져오기
+        Long memberId = 1L; // 임시 memberId
+
+        StoreResponse storeResponse = storeService.updateStore(storeId, memberId, request);
+
+        return ApiResponse.success(storeResponse);
+    }
 }

--- a/src/main/java/com/sparta/couponpop/domain/store/entity/Store.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/entity/Store.java
@@ -142,7 +142,8 @@ public class Store extends BaseEntity {
                                 double longitude, 
                                 String imageUrl,
                                 StoreCategory storeCategory, 
-                                LocalTime weekdayOpenTime, LocalTime weekdayCloseTime,
+                                LocalTime weekdayOpenTime, 
+                                LocalTime weekdayCloseTime,
                                 LocalTime weekendOpenTime, 
                                 LocalTime weekendCloseTime) {
         this.name = name;

--- a/src/main/java/com/sparta/couponpop/domain/store/entity/Store.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/entity/Store.java
@@ -70,10 +70,20 @@ public class Store extends BaseEntity {
     private LocalDateTime deletedAt;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private Store(Member member, String name, String phone, String description, String businessNumber,
-                 String address, double latitude, double longitude, String imageUrl,
-                 StoreCategory storeCategory, LocalTime weekdayOpenTime, LocalTime weekdayCloseTime,
-                 LocalTime weekendOpenTime, LocalTime weekendCloseTime) {
+    private Store(Member member, 
+                String name, 
+                String phone, 
+                String description, 
+                String businessNumber,
+                String address, 
+                double latitude, 
+                double longitude, 
+                String imageUrl,
+                StoreCategory storeCategory, 
+                LocalTime weekdayOpenTime, 
+                LocalTime weekdayCloseTime,
+                LocalTime weekendOpenTime, 
+                LocalTime weekendCloseTime) {
         this.member = member;
         this.name = name;
         this.phone = phone;
@@ -123,10 +133,18 @@ public class Store extends BaseEntity {
                 .build();
     }
 
-    public void updateStoreInfo(String name, String phone, String description, String businessNumber,
-                              String address, double latitude, double longitude, String imageUrl,
-                              StoreCategory storeCategory, LocalTime weekdayOpenTime, LocalTime weekdayCloseTime,
-                              LocalTime weekendOpenTime, LocalTime weekendCloseTime) {
+    public void updateStoreInfo(String name, 
+                                String phone, 
+                                String description, 
+                                String businessNumber,
+                                String address, 
+                                double latitude, 
+                                double longitude, 
+                                String imageUrl,
+                                StoreCategory storeCategory, 
+                                LocalTime weekdayOpenTime, LocalTime weekdayCloseTime,
+                                LocalTime weekendOpenTime, 
+                                LocalTime weekendCloseTime) {
         this.name = name;
         this.phone = phone;
         this.description = description;

--- a/src/main/java/com/sparta/couponpop/domain/store/entity/Store.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/entity/Store.java
@@ -109,4 +109,23 @@ public class Store extends BaseEntity {
                 .weekendCloseTime(weekendCloseTime)
                 .build();
     }
+
+    public void updateStoreInfo(String name, String phone, String description, String businessNumber,
+                              String address, double latitude, double longitude, String imageUrl,
+                              StoreCategory storeCategory, LocalTime weekdayOpenTime, LocalTime weekdayCloseTime,
+                              LocalTime weekendOpenTime, LocalTime weekendCloseTime) {
+        this.name = name;
+        this.phone = phone;
+        this.description = description;
+        this.businessNumber = businessNumber;
+        this.address = address;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.imageUrl = imageUrl;
+        this.storeCategory = storeCategory;
+        this.weekdayOpenTime = weekdayOpenTime;
+        this.weekdayCloseTime = weekdayCloseTime;
+        this.weekendOpenTime = weekendOpenTime;
+        this.weekendCloseTime = weekendCloseTime;
+    }
 }

--- a/src/main/java/com/sparta/couponpop/domain/store/exception/StoreErrorCode.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/exception/StoreErrorCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum StoreErrorCode implements ErrorCode {
 
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 회원입니다."),
-    STORE_NOT_FOUND(HttpStatus.BAD_REQUEST, "매장을 찾을 수 없습니다.");
+    STORE_NOT_FOUND(HttpStatus.BAD_REQUEST, "매장을 찾을 수 없습니다."),
+    STORE_UPDATE_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "매장 수정 권한이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/sparta/couponpop/domain/store/exception/StoreErrorCode.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/exception/StoreErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum StoreErrorCode implements ErrorCode {
 
-    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 회원입니다.");
+    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 회원입니다."),
+    STORE_NOT_FOUND(HttpStatus.BAD_REQUEST, "매장을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/sparta/couponpop/domain/store/service/StoreService.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/service/StoreService.java
@@ -51,7 +51,7 @@ public class StoreService {
     public StoreResponse updateStore(Long storeId, Long memberId, CreateStoreRequest request) {
 
         Store store = storeRepository.findById(storeId)
-                .orElseThrow(() -> new IllegalArgumentException("매장을 찾을 수 없습니다."));
+                .orElseThrow(() -> new GlobalException(StoreErrorCode.STORE_NOT_FOUND));
 
         // TODO: 인증 구현 후 매장 소유자 검증 로직 추가
         // if (!store.getMemberId().equals(memberId)) {

--- a/src/main/java/com/sparta/couponpop/domain/store/service/StoreService.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/service/StoreService.java
@@ -38,4 +38,36 @@ public class StoreService {
 
         return StoreResponse.from(savedStore);
     }
+
+    @Transactional
+    public StoreResponse updateStore(Long storeId, Long memberId, CreateStoreRequest request) {
+
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new IllegalArgumentException("매장을 찾을 수 없습니다."));
+
+        // TODO: 인증 구현 후 매장 소유자 검증 로직 추가
+        // if (!store.getMemberId().equals(memberId)) {
+        //     throw new IllegalArgumentException("매장 수정 권한이 없습니다.");
+        // }
+
+        store.updateStoreInfo(
+                request.name(),
+                request.phone(),
+                request.description(),
+                request.businessNumber(),
+                request.address(),
+                request.latitude(),
+                request.longitude(),
+                request.imageUrl(),
+                request.storeCategory(),
+                request.weekdayOpenTime(),
+                request.weekdayCloseTime(),
+                request.weekendOpenTime(),
+                request.weekendCloseTime()
+        );
+
+        Store updatedStore = storeRepository.save(store);
+
+        return StoreResponse.from(updatedStore);
+    }
 }

--- a/src/main/java/com/sparta/couponpop/domain/store/service/StoreService.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/service/StoreService.java
@@ -53,10 +53,10 @@ public class StoreService {
         Store store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new GlobalException(StoreErrorCode.STORE_NOT_FOUND));
 
-        // TODO: 인증 구현 후 매장 소유자 검증 로직 추가
-        // if (!store.getMemberId().equals(memberId)) {
-        //     throw new IllegalArgumentException("매장 수정 권한이 없습니다.");
-        // }
+        // 매장 소유자 검증
+        if (!store.getMember().getId().equals(memberId)) {
+            throw new GlobalException(StoreErrorCode.STORE_UPDATE_PERMISSION_DENIED);
+        }
 
         store.updateStoreInfo(
                 request.name(),

--- a/src/main/java/com/sparta/couponpop/domain/store/service/StoreService.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/service/StoreService.java
@@ -74,8 +74,6 @@ public class StoreService {
                 request.weekendCloseTime()
         );
 
-        Store updatedStore = storeRepository.save(store);
-
-        return StoreResponse.from(updatedStore);
+        return StoreResponse.from(store);
     }
 }

--- a/src/test/java/com/sparta/couponpop/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/store/service/StoreServiceTest.java
@@ -192,7 +192,8 @@ class StoreServiceTest {
         Long storeId = 1L;
         Long memberId = 1L;
         CreateStoreRequest request = createUpdateRequest();
-        Store existingStore = createStore(memberId);
+        Member member = createMember(memberId);
+        Store existingStore = createStore(member);
         existingStore.updateStoreInfo(
                 request.name(),
                 request.phone(),
@@ -210,7 +211,7 @@ class StoreServiceTest {
         );
 
         given(storeRepository.findById(storeId))
-                .willReturn(Optional.of(createStore(memberId)));
+                .willReturn(Optional.of(createStore(member)));
         given(storeRepository.save(any(Store.class)))
                 .willReturn(existingStore);
 
@@ -265,7 +266,8 @@ class StoreServiceTest {
         Long storeId = 1L;
         Long memberId = 1L;
         CreateStoreRequest request = createFoodUpdateRequest();
-        Store existingStore = createStore(memberId);
+        Member member = createMember(memberId);
+        Store existingStore = createStore(member);
         existingStore.updateStoreInfo(
                 request.name(),
                 request.phone(),
@@ -283,7 +285,7 @@ class StoreServiceTest {
         );
 
         given(storeRepository.findById(storeId))
-                .willReturn(Optional.of(createStore(memberId)));
+                .willReturn(Optional.of(createStore(member)));
         given(storeRepository.save(any(Store.class)))
                 .willReturn(existingStore);
 

--- a/src/test/java/com/sparta/couponpop/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/store/service/StoreServiceTest.java
@@ -301,6 +301,30 @@ class StoreServiceTest {
         then(storeRepository).should(times(1)).save(any(Store.class));
     }
 
+    @Test
+    @DisplayName("다른 회원의 매장 수정 시 권한 없음 예외 발생")
+    void updateStore_WithDifferentMember_ThrowsPermissionException() {
+
+        // given
+        Long storeId = 1L;
+        Long memberId = 1L;
+        Long otherMemberId = 2L;
+        CreateStoreRequest request = createUpdateRequest();
+        Member otherMember = createMember(otherMemberId);
+        Store store = createStore(otherMember);
+
+        given(storeRepository.findById(storeId))
+                .willReturn(Optional.of(store));
+
+        // when & then
+        assertThatThrownBy(() -> storeService.updateStore(storeId, memberId, request))
+                .isInstanceOf(GlobalException.class)
+                .hasMessage("매장 수정 권한이 없습니다.");
+
+        then(storeRepository).should(times(1)).findById(storeId);
+        then(storeRepository).should(times(0)).save(any(Store.class));
+    }
+
     private CreateStoreRequest createStoreRequest() {
         return new CreateStoreRequest(
                 "스타벅스 홍대점",

--- a/src/test/java/com/sparta/couponpop/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/store/service/StoreServiceTest.java
@@ -13,8 +13,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalTime;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -159,6 +161,120 @@ class StoreServiceTest {
         then(storeRepository).should(times(1)).save(any(Store.class));
     }
 
+    @Test
+    @DisplayName("매장 수정 성공")
+    void updateStore_Success() {
+
+        // given
+        Long storeId = 1L;
+        Long memberId = 1L;
+        CreateStoreRequest request = createUpdateRequest();
+        Store existingStore = createStore(memberId);
+        existingStore.updateStoreInfo(
+                request.name(),
+                request.phone(),
+                request.description(),
+                request.businessNumber(),
+                request.address(),
+                request.latitude(),
+                request.longitude(),
+                request.imageUrl(),
+                request.storeCategory(),
+                request.weekdayOpenTime(),
+                request.weekdayCloseTime(),
+                request.weekendOpenTime(),
+                request.weekendCloseTime()
+        );
+
+        given(storeRepository.findById(storeId))
+                .willReturn(Optional.of(createStore(memberId)));
+        given(storeRepository.save(any(Store.class)))
+                .willReturn(existingStore);
+
+        // when
+        StoreResponse result = storeService.updateStore(storeId, memberId, request);
+
+        // then
+        assertThat(result.name()).isEqualTo(request.name());
+        assertThat(result.phone()).isEqualTo(request.phone());
+        assertThat(result.description()).isEqualTo(request.description());
+        assertThat(result.businessNumber()).isEqualTo(request.businessNumber());
+        assertThat(result.address()).isEqualTo(request.address());
+        assertThat(result.latitude()).isEqualTo(request.latitude());
+        assertThat(result.longitude()).isEqualTo(request.longitude());
+        assertThat(result.imageUrl()).isEqualTo(request.imageUrl());
+        assertThat(result.storeCategory()).isEqualTo(request.storeCategory());
+        assertThat(result.weekdayOpenTime()).isEqualTo(request.weekdayOpenTime());
+        assertThat(result.weekdayCloseTime()).isEqualTo(request.weekdayCloseTime());
+        assertThat(result.weekendOpenTime()).isEqualTo(request.weekendOpenTime());
+        assertThat(result.weekendCloseTime()).isEqualTo(request.weekendCloseTime());
+
+        then(storeRepository).should(times(1)).findById(storeId);
+        then(storeRepository).should(times(1)).save(any(Store.class));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 매장 수정 시 예외 발생")
+    void updateStore_WithNonExistentStore_ThrowsException() {
+
+        // given
+        Long storeId = 999L;
+        Long memberId = 1L;
+        CreateStoreRequest request = createUpdateRequest();
+
+        given(storeRepository.findById(storeId))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> storeService.updateStore(storeId, memberId, request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("매장을 찾을 수 없습니다.");
+
+        then(storeRepository).should(times(1)).findById(storeId);
+        then(storeRepository).should(times(0)).save(any(Store.class));
+    }
+
+    @Test
+    @DisplayName("다른 카테고리로 매장 수정 성공")
+    void updateStore_WithDifferentCategory_Success() {
+
+        // given
+        Long storeId = 1L;
+        Long memberId = 1L;
+        CreateStoreRequest request = createFoodUpdateRequest();
+        Store existingStore = createStore(memberId);
+        existingStore.updateStoreInfo(
+                request.name(),
+                request.phone(),
+                request.description(),
+                request.businessNumber(),
+                request.address(),
+                request.latitude(),
+                request.longitude(),
+                request.imageUrl(),
+                request.storeCategory(),
+                request.weekdayOpenTime(),
+                request.weekdayCloseTime(),
+                request.weekendOpenTime(),
+                request.weekendCloseTime()
+        );
+
+        given(storeRepository.findById(storeId))
+                .willReturn(Optional.of(createStore(memberId)));
+        given(storeRepository.save(any(Store.class)))
+                .willReturn(existingStore);
+
+        // when
+        StoreResponse result = storeService.updateStore(storeId, memberId, request);
+
+        // then
+        assertThat(result.storeCategory()).isEqualTo(StoreCategory.FOOD);
+        assertThat(result.name()).isEqualTo("맛있는 식당");
+
+        then(storeRepository).should(times(1)).findById(storeId);
+        then(storeRepository).should(times(1)).save(any(Store.class));
+    }
+
     private CreateStoreRequest createStoreRequest() {
         return new CreateStoreRequest(
                 "스타벅스 홍대점",
@@ -217,6 +333,42 @@ class StoreServiceTest {
     private Store createFoodStore(Long memberId) {
         return Store.createStore(
                 memberId,
+                "맛있는 식당",
+                "0312345678",
+                "정말 맛있는 음식을 제공하는 식당입니다.",
+                "9876543210",
+                "서울시 강남구 테헤란로 456",
+                37.5665,
+                126.9780,
+                "https://example.com/food-store-image.jpg",
+                StoreCategory.FOOD,
+                LocalTime.of(11, 0),
+                LocalTime.of(22, 0),
+                LocalTime.of(12, 0),
+                LocalTime.of(23, 0)
+        );
+    }
+
+    private CreateStoreRequest createUpdateRequest() {
+        return new CreateStoreRequest(
+                "스타벅스 홍대점 수정",
+                "0212345679",
+                "홍대 중심가에 위치한 스타벅스입니다. (수정됨)",
+                "1234567891",
+                "서울시 마포구 홍익로 124",
+                37.5666,
+                126.9781,
+                "https://example.com/store-image-updated.jpg",
+                StoreCategory.CAFE,
+                LocalTime.of(8, 0),
+                LocalTime.of(23, 0),
+                LocalTime.of(9, 0),
+                LocalTime.of(23, 30)
+        );
+    }
+
+    private CreateStoreRequest createFoodUpdateRequest() {
+        return new CreateStoreRequest(
                 "맛있는 식당",
                 "0312345678",
                 "정말 맛있는 음식을 제공하는 식당입니다.",

--- a/src/test/java/com/sparta/couponpop/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/store/service/StoreServiceTest.java
@@ -1,5 +1,6 @@
 package com.sparta.couponpop.domain.store.service;
 
+import com.sparta.couponpop.common.exception.GlobalException;
 import com.sparta.couponpop.domain.member.entity.Member;
 import com.sparta.couponpop.domain.member.enums.MemberType;
 import com.sparta.couponpop.domain.member.repository.MemberRepository;
@@ -251,7 +252,7 @@ class StoreServiceTest {
 
         // when & then
         assertThatThrownBy(() -> storeService.updateStore(storeId, memberId, request))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(GlobalException.class)
                 .hasMessage("매장을 찾을 수 없습니다.");
 
         then(storeRepository).should(times(1)).findById(storeId);

--- a/src/test/java/com/sparta/couponpop/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/store/service/StoreServiceTest.java
@@ -195,47 +195,19 @@ class StoreServiceTest {
         CreateStoreRequest request = createUpdateRequest();
         Member member = createMember(memberId);
         Store existingStore = createStore(member);
-        existingStore.updateStoreInfo(
-                request.name(),
-                request.phone(),
-                request.description(),
-                request.businessNumber(),
-                request.address(),
-                request.latitude(),
-                request.longitude(),
-                request.imageUrl(),
-                request.storeCategory(),
-                request.weekdayOpenTime(),
-                request.weekdayCloseTime(),
-                request.weekendOpenTime(),
-                request.weekendCloseTime()
-        );
 
         given(storeRepository.findById(storeId))
-                .willReturn(Optional.of(createStore(member)));
-        given(storeRepository.save(any(Store.class)))
-                .willReturn(existingStore);
-
+                .willReturn(Optional.of(existingStore));
         // when
         StoreResponse result = storeService.updateStore(storeId, memberId, request);
 
         // then
         assertThat(result.name()).isEqualTo(request.name());
         assertThat(result.phone()).isEqualTo(request.phone());
-        assertThat(result.description()).isEqualTo(request.description());
-        assertThat(result.businessNumber()).isEqualTo(request.businessNumber());
-        assertThat(result.address()).isEqualTo(request.address());
-        assertThat(result.latitude()).isEqualTo(request.latitude());
-        assertThat(result.longitude()).isEqualTo(request.longitude());
-        assertThat(result.imageUrl()).isEqualTo(request.imageUrl());
         assertThat(result.storeCategory()).isEqualTo(request.storeCategory());
-        assertThat(result.weekdayOpenTime()).isEqualTo(request.weekdayOpenTime());
-        assertThat(result.weekdayCloseTime()).isEqualTo(request.weekdayCloseTime());
-        assertThat(result.weekendOpenTime()).isEqualTo(request.weekendOpenTime());
-        assertThat(result.weekendCloseTime()).isEqualTo(request.weekendCloseTime());
 
         then(storeRepository).should(times(1)).findById(storeId);
-        then(storeRepository).should(times(1)).save(any(Store.class));
+        then(storeRepository).should(times(0)).save(any(Store.class));
     }
 
     @Test
@@ -269,27 +241,9 @@ class StoreServiceTest {
         CreateStoreRequest request = createFoodUpdateRequest();
         Member member = createMember(memberId);
         Store existingStore = createStore(member);
-        existingStore.updateStoreInfo(
-                request.name(),
-                request.phone(),
-                request.description(),
-                request.businessNumber(),
-                request.address(),
-                request.latitude(),
-                request.longitude(),
-                request.imageUrl(),
-                request.storeCategory(),
-                request.weekdayOpenTime(),
-                request.weekdayCloseTime(),
-                request.weekendOpenTime(),
-                request.weekendCloseTime()
-        );
 
         given(storeRepository.findById(storeId))
-                .willReturn(Optional.of(createStore(member)));
-        given(storeRepository.save(any(Store.class)))
-                .willReturn(existingStore);
-
+                .willReturn(Optional.of(existingStore));
         // when
         StoreResponse result = storeService.updateStore(storeId, memberId, request);
 
@@ -298,7 +252,7 @@ class StoreServiceTest {
         assertThat(result.name()).isEqualTo("맛있는 식당");
 
         then(storeRepository).should(times(1)).findById(storeId);
-        then(storeRepository).should(times(1)).save(any(Store.class));
+        then(storeRepository).should(times(0)).save(any(Store.class));
     }
 
     @Test


### PR DESCRIPTION
## 🔗 **연관된 이슈**
> close #이슈번호

Closes #22 
<br>

## 📝 **작업 내용**

1. Store 엔티티 개선
- updateStoreInfo() 메서드 추가
- 매장 정보를 업데이트하는 비즈니스 로직

2. StoreService
- updateStore() 메서드 추가
- 매장 존재 여부 검증

3. StoreController
- /api/v1/owner/stores/{storeId} 엔드포인트 추가

4. 테스트 코드
<br>

## 📸 **스크린샷 (선택)**

<br>
