### PR TITLE
feat: 사장 매장 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/sparta/couponpop/domain/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/controller/StoreController.java
@@ -1,6 +1,8 @@
 package com.sparta.couponpop.domain.store.controller;
 
 import com.sparta.couponpop.common.response.ApiResponse;
+import com.sparta.couponpop.common.security.annotation.CurrentMember;
+import com.sparta.couponpop.common.security.dto.AuthMember;
 import com.sparta.couponpop.domain.store.dto.request.CreateStoreRequest;
 import com.sparta.couponpop.domain.store.dto.response.StoreResponse;
 import com.sparta.couponpop.domain.store.service.StoreService;
@@ -9,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/v1/owner/stores")
 @RequiredArgsConstructor
@@ -16,24 +20,26 @@ public class StoreController {
 
     private final StoreService storeService;
 
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<StoreResponse>>> getStores(@CurrentMember AuthMember authMember) {
+
+        List<StoreResponse> storeResponses = storeService.getStoresByOwner(authMember.id());
+
+        return ApiResponse.success(storeResponses);
+    }
+
     @PostMapping
-    public ResponseEntity<ApiResponse<StoreResponse>> createStore(@RequestBody @Valid CreateStoreRequest request) {
+    public ResponseEntity<ApiResponse<StoreResponse>> createStore(@CurrentMember AuthMember authMember, @RequestBody @Valid CreateStoreRequest request) {
 
-        // TODO: 인증 구현 후 @LoginUserResolver로 memberId 가져오기
-        Long memberId = 1L; // 임시 memberId
-
-        StoreResponse storeResponse = storeService.createStore(memberId, request);
+        StoreResponse storeResponse = storeService.createStore(authMember.id(), request);
 
         return ApiResponse.created(storeResponse);
     }
 
     @PutMapping("/{storeId}")
-    public ResponseEntity<ApiResponse<StoreResponse>> updateStore(@PathVariable Long storeId, @RequestBody @Valid CreateStoreRequest request) {
+    public ResponseEntity<ApiResponse<StoreResponse>> updateStore(@CurrentMember AuthMember authMember, @PathVariable Long storeId, @RequestBody @Valid CreateStoreRequest request) {
 
-        // TODO: 인증 구현 후 @LoginUserResolver로 memberId 가져오기
-        Long memberId = 1L; // 임시 memberId
-
-        StoreResponse storeResponse = storeService.updateStore(storeId, memberId, request);
+        StoreResponse storeResponse = storeService.updateStore(storeId, authMember.id(), request);
 
         return ApiResponse.success(storeResponse);
     }

--- a/src/main/java/com/sparta/couponpop/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/repository/StoreRepository.java
@@ -3,6 +3,10 @@ package com.sparta.couponpop.domain.store.repository;
 import com.sparta.couponpop.domain.store.entity.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface StoreRepository extends JpaRepository<Store, Long> {
+    
+    List<Store> findByMemberIdOrderByCreatedAtDesc(Long memberId);
 }
 

--- a/src/main/java/com/sparta/couponpop/domain/store/service/StoreService.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/service/StoreService.java
@@ -12,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class StoreService {
@@ -75,5 +77,15 @@ public class StoreService {
         );
 
         return StoreResponse.from(store);
+    }
+
+    @Transactional(readOnly = true)
+    public List<StoreResponse> getStoresByOwner(Long memberId) {
+
+        List<Store> stores = storeRepository.findByMemberIdOrderByCreatedAtDesc(memberId);
+
+        return stores.stream()
+                .map(StoreResponse::from)
+                .toList();
     }
 }


### PR DESCRIPTION
## 🔗 **연관된 이슈**
> close #이슈번호

Closes #23
<br>

## 📝 **작업 내용**

1. Repository 개선
- 사장별 매장 목록 조회 메서드 추가
- 생성일 기준 내림차순 정렬 (최신 매장 우선)

2. Service & Controller 확장
- 매장 목록 조회 비즈니스 로직 구현

3. 인증/인가
- 기존 하드코딩된 memberId = 1L 제거
- @CurrentMember AuthMember 파라미터로 실제 인증된 사용자 정보 활용
<br>
## 📸 **스크린샷 (선택)**

<br>
