### PR TITLE
feat: 회원 FCM 토큰 갱신 및 생성 API 구현

### DIFF
--- a/src/main/java/com/sparta/couponpop/domain/member/controller/MemberFcmTokenController.java
+++ b/src/main/java/com/sparta/couponpop/domain/member/controller/MemberFcmTokenController.java
@@ -21,8 +21,7 @@ public class MemberFcmTokenController {
     private final MemberFcmTokenService memberFcmTokenService;
 
     @PostMapping("/members/fcm-token")
-    public ResponseEntity<ApiResponse<Void>> upsertMemberFcmToken(@RequestBody @Valid MemberFcmTokenRequest request,
-                                                                  @CurrentMember AuthMember authMember) {
+    public ResponseEntity<ApiResponse<Void>> upsertMemberFcmToken(@RequestBody @Valid MemberFcmTokenRequest request, @CurrentMember AuthMember authMember) {
         memberFcmTokenService.upsertTokenForMember(request, authMember.id());
         return ApiResponse.success(null);
     }

--- a/src/main/java/com/sparta/couponpop/domain/member/controller/MemberFcmTokenController.java
+++ b/src/main/java/com/sparta/couponpop/domain/member/controller/MemberFcmTokenController.java
@@ -1,0 +1,30 @@
+package com.sparta.couponpop.domain.member.controller;
+
+import com.sparta.couponpop.common.response.ApiResponse;
+import com.sparta.couponpop.common.security.annotation.CurrentMember;
+import com.sparta.couponpop.common.security.dto.AuthMember;
+import com.sparta.couponpop.domain.member.dto.request.MemberFcmTokenRequest;
+import com.sparta.couponpop.domain.member.service.MemberFcmTokenService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class MemberFcmTokenController {
+
+    private final MemberFcmTokenService memberFcmTokenService;
+
+    @PostMapping("/members/fcm-token")
+    public ResponseEntity<ApiResponse<Void>> upsertMemberFcmToken(@RequestBody @Valid MemberFcmTokenRequest request,
+                                                                  @CurrentMember AuthMember authMember) {
+        memberFcmTokenService.upsertTokenForMember(request, authMember.id());
+        return ApiResponse.success(null);
+    }
+
+}

--- a/src/main/java/com/sparta/couponpop/domain/member/dto/request/MemberFcmTokenRequest.java
+++ b/src/main/java/com/sparta/couponpop/domain/member/dto/request/MemberFcmTokenRequest.java
@@ -1,0 +1,11 @@
+package com.sparta.couponpop.domain.member.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record MemberFcmTokenRequest(
+        String fcmToken,
+        String deviceType,
+        String deviceIdentifier
+) {
+}

--- a/src/main/java/com/sparta/couponpop/domain/member/entity/MemberFcmToken.java
+++ b/src/main/java/com/sparta/couponpop/domain/member/entity/MemberFcmToken.java
@@ -29,7 +29,7 @@ public class MemberFcmToken extends BaseEntity {
 
     private String deviceIdentifier;
 
-    private int notificationEnabled;
+    private boolean notificationEnabled;
 
     private LocalDateTime lastUsedAt;
 
@@ -38,7 +38,7 @@ public class MemberFcmToken extends BaseEntity {
                            String fcmToken,
                            String deviceType,
                            String deviceIdentifier,
-                           int notificationEnabled,
+                           boolean notificationEnabled,
                            LocalDateTime lastUsedAt) {
         this.member = member;
         this.fcmToken = fcmToken;
@@ -52,12 +52,14 @@ public class MemberFcmToken extends BaseEntity {
                                     String fcmToken,
                                     String deviceType,
                                     String deviceIdentifier,
+                                    boolean notificationEnabled,
                                     LocalDateTime lastUsedAt) {
         return MemberFcmToken.builder()
                 .member(member)
                 .fcmToken(fcmToken)
                 .deviceType(deviceType)
                 .deviceIdentifier(deviceIdentifier)
+                .notificationEnabled(notificationEnabled)
                 .lastUsedAt(lastUsedAt)
                 .build();
     }

--- a/src/main/java/com/sparta/couponpop/domain/member/entity/MemberFcmToken.java
+++ b/src/main/java/com/sparta/couponpop/domain/member/entity/MemberFcmToken.java
@@ -1,0 +1,76 @@
+package com.sparta.couponpop.domain.member.entity;
+
+import com.sparta.couponpop.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "member_fcm_tokens")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberFcmToken extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    private String fcmToken;
+
+    private String deviceType;
+
+    private String deviceIdentifier;
+
+    private int notificationEnabled;
+
+    private LocalDateTime lastUsedAt;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private MemberFcmToken(Member member,
+                           String fcmToken,
+                           String deviceType,
+                           String deviceIdentifier,
+                           int notificationEnabled,
+                           LocalDateTime lastUsedAt) {
+        this.member = member;
+        this.fcmToken = fcmToken;
+        this.deviceType = deviceType;
+        this.deviceIdentifier = deviceIdentifier;
+        this.notificationEnabled = notificationEnabled;
+        this.lastUsedAt = lastUsedAt;
+    }
+
+    public static MemberFcmToken of(Member member,
+                                    String fcmToken,
+                                    String deviceType,
+                                    String deviceIdentifier,
+                                    LocalDateTime lastUsedAt) {
+        return MemberFcmToken.builder()
+                .member(member)
+                .fcmToken(fcmToken)
+                .deviceType(deviceType)
+                .deviceIdentifier(deviceIdentifier)
+                .lastUsedAt(lastUsedAt)
+                .build();
+    }
+
+    public void updateFcmToken(String fcmToken, LocalDateTime lastUsedAt) {
+        this.fcmToken = fcmToken;
+        this.lastUsedAt = lastUsedAt;
+    }
+
+    public void updateMemberAndDeviceIdentifier(Member member, String deviceIdentifier, LocalDateTime lastUsedAt) {
+        this.member = member;
+        this.deviceIdentifier = deviceIdentifier;
+        this.lastUsedAt = lastUsedAt;
+    }
+
+}

--- a/src/main/java/com/sparta/couponpop/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/sparta/couponpop/domain/member/exception/MemberErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum MemberErrorCode implements ErrorCode {
 
+    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 회원입니다."),
     EMAIL_DUPLICATED(HttpStatus.BAD_REQUEST, "이미 사용중인 이메일입니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/sparta/couponpop/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/sparta/couponpop/domain/member/exception/MemberErrorCode.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum MemberErrorCode implements ErrorCode {
 
-    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 회원입니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
     EMAIL_DUPLICATED(HttpStatus.BAD_REQUEST, "이미 사용중인 이메일입니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/sparta/couponpop/domain/member/repository/MemberFcmTokenRepository.java
+++ b/src/main/java/com/sparta/couponpop/domain/member/repository/MemberFcmTokenRepository.java
@@ -1,0 +1,14 @@
+package com.sparta.couponpop.domain.member.repository;
+
+import com.sparta.couponpop.domain.member.entity.Member;
+import com.sparta.couponpop.domain.member.entity.MemberFcmToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberFcmTokenRepository extends JpaRepository<MemberFcmToken, Long> {
+
+    Optional<MemberFcmToken> findByMemberAndDeviceIdentifier(Member member, String deviceIdentifier);
+
+    Optional<MemberFcmToken> findByFcmToken(String fcmToken);
+}

--- a/src/main/java/com/sparta/couponpop/domain/member/service/MemberFcmTokenService.java
+++ b/src/main/java/com/sparta/couponpop/domain/member/service/MemberFcmTokenService.java
@@ -65,6 +65,7 @@ public class MemberFcmTokenService {
                             request.fcmToken(),
                             request.deviceType(),
                             request.deviceIdentifier(),
+                            true,
                             LocalDateTime.now()
                     )
             );

--- a/src/main/java/com/sparta/couponpop/domain/member/service/MemberFcmTokenService.java
+++ b/src/main/java/com/sparta/couponpop/domain/member/service/MemberFcmTokenService.java
@@ -1,0 +1,76 @@
+package com.sparta.couponpop.domain.member.service;
+
+import com.sparta.couponpop.common.exception.GlobalException;
+import com.sparta.couponpop.domain.member.dto.request.MemberFcmTokenRequest;
+import com.sparta.couponpop.domain.member.entity.Member;
+import com.sparta.couponpop.domain.member.entity.MemberFcmToken;
+import com.sparta.couponpop.domain.member.exception.MemberErrorCode;
+import com.sparta.couponpop.domain.member.repository.MemberFcmTokenRepository;
+import com.sparta.couponpop.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberFcmTokenService {
+
+    private final MemberFcmTokenRepository memberFcmTokenRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void upsertTokenForMember(MemberFcmTokenRequest request,
+                                     Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GlobalException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        // 중복 토큰 조회
+        Optional<MemberFcmToken> duplicatedToken = memberFcmTokenRepository.findByFcmToken(request.fcmToken());
+        // 중복 토큰이 있다면 memberId, deviceIdentifier 갱신 후 return
+        if (duplicatedToken.isPresent()) {
+            duplicatedToken.get().updateMemberAndDeviceIdentifier(
+                    member,
+                    request.deviceIdentifier(),
+                    LocalDateTime.now()
+            );
+
+            log.debug("[FCM TOKEN] 중복 토큰 갱신: memberId={}, deviceIdentifier={}",
+                    member.getId(), request.deviceIdentifier());
+
+            return;
+        }
+
+        // 중복 토큰이 없다면 기존 토큰 조회 후 UPSERT
+        Optional<MemberFcmToken> activeToken = memberFcmTokenRepository.findByMemberAndDeviceIdentifier(member, request.deviceIdentifier());
+        if (activeToken.isPresent()) {
+            // 존재한다면 기존 토큰 갱신
+            activeToken.get().updateFcmToken(
+                    request.fcmToken(),
+                    LocalDateTime.now()
+            );
+
+            log.debug("[FCM TOKEN] 기존 토큰 갱신: memberId={}, deviceIdentifier={}, fcmToken={}",
+                    member.getId(), request.deviceIdentifier(), request.fcmToken());
+
+        } else {
+            // 존재하지 않는다면 신규 토큰 저장
+            memberFcmTokenRepository.save(
+                    MemberFcmToken.of(
+                            member,
+                            request.fcmToken(),
+                            request.deviceType(),
+                            request.deviceIdentifier(),
+                            LocalDateTime.now()
+                    )
+            );
+
+            log.debug("[FCM TOKEN] 신규 토큰 저장: memberId={}, deviceIdentifier={}, fcmToken={}",
+                    member.getId(), request.deviceIdentifier(), request.fcmToken());
+        }
+    }
+}

--- a/src/main/java/com/sparta/couponpop/domain/member/service/MemberFcmTokenService.java
+++ b/src/main/java/com/sparta/couponpop/domain/member/service/MemberFcmTokenService.java
@@ -24,10 +24,11 @@ public class MemberFcmTokenService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public void upsertTokenForMember(MemberFcmTokenRequest request,
-                                     Long memberId) {
+    public void upsertTokenForMember(MemberFcmTokenRequest request, Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new GlobalException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        final LocalDateTime now = LocalDateTime.now();
 
         // 중복 토큰 조회
         Optional<MemberFcmToken> duplicatedToken = memberFcmTokenRepository.findByFcmToken(request.fcmToken());
@@ -36,7 +37,7 @@ public class MemberFcmTokenService {
             duplicatedToken.get().updateMemberAndDeviceIdentifier(
                     member,
                     request.deviceIdentifier(),
-                    LocalDateTime.now()
+                    now
             );
 
             log.debug("[FCM TOKEN] 중복 토큰 갱신: memberId={}, deviceIdentifier={}",
@@ -51,7 +52,7 @@ public class MemberFcmTokenService {
             // 존재한다면 기존 토큰 갱신
             activeToken.get().updateFcmToken(
                     request.fcmToken(),
-                    LocalDateTime.now()
+                    now
             );
 
             log.debug("[FCM TOKEN] 기존 토큰 갱신: memberId={}, deviceIdentifier={}, fcmToken={}",
@@ -66,7 +67,7 @@ public class MemberFcmTokenService {
                             request.deviceType(),
                             request.deviceIdentifier(),
                             true,
-                            LocalDateTime.now()
+                            now
                     )
             );
 

--- a/src/main/java/com/sparta/couponpop/domain/member/service/MemberFcmTokenService.java
+++ b/src/main/java/com/sparta/couponpop/domain/member/service/MemberFcmTokenService.java
@@ -47,32 +47,27 @@ public class MemberFcmTokenService {
         }
 
         // 중복 토큰이 없다면 기존 토큰 조회 후 UPSERT
-        Optional<MemberFcmToken> activeToken = memberFcmTokenRepository.findByMemberAndDeviceIdentifier(member, request.deviceIdentifier());
-        if (activeToken.isPresent()) {
-            // 존재한다면 기존 토큰 갱신
-            activeToken.get().updateFcmToken(
-                    request.fcmToken(),
-                    now
-            );
-
-            log.debug("[FCM TOKEN] 기존 토큰 갱신: memberId={}, deviceIdentifier={}, fcmToken={}",
-                    member.getId(), request.deviceIdentifier(), request.fcmToken());
-
-        } else {
-            // 존재하지 않는다면 신규 토큰 저장
-            memberFcmTokenRepository.save(
-                    MemberFcmToken.of(
-                            member,
-                            request.fcmToken(),
-                            request.deviceType(),
-                            request.deviceIdentifier(),
-                            true,
-                            now
-                    )
-            );
-
-            log.debug("[FCM TOKEN] 신규 토큰 저장: memberId={}, deviceIdentifier={}, fcmToken={}",
-                    member.getId(), request.deviceIdentifier(), request.fcmToken());
-        }
+        memberFcmTokenRepository.findByMemberAndDeviceIdentifier(member, request.deviceIdentifier())
+                .ifPresentOrElse(
+                        activeToken -> {
+                            activeToken.updateFcmToken(request.fcmToken(), now);
+                            log.debug("[FCM TOKEN] 기존 토큰 갱신: memberId={}, deviceIdentifier={}, fcmToken={}",
+                                    member.getId(), request.deviceIdentifier(), request.fcmToken());
+                        },
+                        () -> {
+                            memberFcmTokenRepository.save(
+                                    MemberFcmToken.of(
+                                            member,
+                                            request.fcmToken(),
+                                            request.deviceType(),
+                                            request.deviceIdentifier(),
+                                            true,
+                                            now
+                                    )
+                            );
+                            log.debug("[FCM TOKEN] 신규 토큰 저장: memberId={}, deviceIdentifier={}, fcmToken={}",
+                                    member.getId(), request.deviceIdentifier(), request.fcmToken());
+                        }
+                );
     }
 }

--- a/src/main/resources/db/migration/V6__create_member_fcm_token_table.sql
+++ b/src/main/resources/db/migration/V6__create_member_fcm_token_table.sql
@@ -1,0 +1,19 @@
+CREATE TABLE member_fcm_tokens
+(
+    id                   BIGINT AUTO_INCREMENT PRIMARY KEY,
+    member_id            BIGINT       NOT NULL COMMENT 'FCM 토큰을 보유한 회원 ID',
+    fcm_token            VARCHAR(255) NOT NULL COMMENT 'FCM에서 발급된 디바이스 토큰 값',
+    device_type          VARCHAR(32)  NOT NULL COMMENT '디바이스 유형(ANDROID, IOS, WEB 등)',
+    device_identifier    VARCHAR(128) NOT NULL COMMENT '디바이스 고유 식별자 또는 로컬 키',
+    notification_enabled BOOLEAN      NOT NULL DEFAULT TRUE COMMENT '사용자 푸시 수신 여부',
+    last_used_at         DATETIME     NULL COMMENT '푸시 발송 성공 또는 앱 사용 기준 최근 사용 시각',
+    created_at           DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '등록일',
+    updated_at           DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일',
+
+    UNIQUE KEY uk_member_fcm_token_member_device (member_id, device_identifier),
+    UNIQUE KEY uk_member_fcm_token_fcm_token (fcm_token),
+
+    FOREIGN KEY (member_id) REFERENCES members (id)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci COMMENT ='회원별 디바이스 FCM 토큰 정보 저장 테이블';

--- a/src/test/java/com/sparta/couponpop/domain/member/controller/MemberFcmTokenControllerTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/member/controller/MemberFcmTokenControllerTest.java
@@ -1,0 +1,78 @@
+package com.sparta.couponpop.domain.member.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.couponpop.common.security.JwtAuthenticationToken;
+import com.sparta.couponpop.common.security.JwtProvider;
+import com.sparta.couponpop.common.security.dto.AuthMember;
+import com.sparta.couponpop.domain.member.dto.request.MemberFcmTokenRequest;
+import com.sparta.couponpop.domain.member.enums.MemberType;
+import com.sparta.couponpop.domain.member.service.MemberFcmTokenService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MemberFcmTokenController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class MemberFcmTokenControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private MemberFcmTokenService memberFcmTokenService;
+
+    @BeforeEach
+    void setUp() {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        AuthMember authMember = AuthMember.from(123L, "testUser", MemberType.CUSTOMER);
+        Authentication authenticationToken = new JwtAuthenticationToken(authMember);
+        context.setAuthentication(authenticationToken);
+        SecurityContextHolder.setContext(context);
+    }
+
+    @Test
+    @DisplayName("회원 FCM 토큰 생성 및 갱신 - 성공")
+    void upsertMemberFcmToken_success() throws Exception {
+        // given
+        MemberFcmTokenRequest request = MemberFcmTokenRequest.builder()
+                .fcmToken("sample_fcm_token")
+                .deviceType("ANDROID")
+                .deviceIdentifier("device-123")
+                .build();
+
+        willDoNothing().given(memberFcmTokenService).upsertTokenForMember(any(MemberFcmTokenRequest.class), anyLong());
+
+        // when & then
+        mockMvc.perform(
+                        post("/api/v1/members/fcm-token")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                )
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+
+}

--- a/src/test/java/com/sparta/couponpop/domain/member/service/MemberFcmTokenServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/member/service/MemberFcmTokenServiceTest.java
@@ -1,0 +1,158 @@
+package com.sparta.couponpop.domain.member.service;
+
+import com.sparta.couponpop.common.exception.GlobalException;
+import com.sparta.couponpop.domain.member.dto.request.MemberFcmTokenRequest;
+import com.sparta.couponpop.domain.member.entity.Member;
+import com.sparta.couponpop.domain.member.entity.MemberFcmToken;
+import com.sparta.couponpop.domain.member.exception.MemberErrorCode;
+import com.sparta.couponpop.domain.member.repository.MemberFcmTokenRepository;
+import com.sparta.couponpop.domain.member.repository.MemberRepository;
+import com.sparta.couponpop.utils.TestUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MemberFcmTokenServiceTest {
+
+    @Mock
+    private MemberFcmTokenRepository memberFcmTokenRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private MemberFcmTokenService memberFcmTokenService;
+
+    @Nested
+    @DisplayName("upsertTokenForMember")
+    class UpsertTokenForMember {
+
+        @Test
+        @DisplayName("중복 토큰이 존재하면 회원과 기기 식별자를 갱신한다")
+        void upsertTokenForMember_thenDuplicatedToken_updatesMemberAndDeviceIdentifier() {
+            // given
+            Long memberId = 1L;
+            Member member = TestUtils.createEntity(Member.class, Map.of("id", memberId));
+            MemberFcmTokenRequest request = MemberFcmTokenRequest.builder()
+                    .fcmToken("fcm-token")
+                    .deviceType("ANDROID")
+                    .deviceIdentifier("device-123")
+                    .build();
+            MemberFcmToken duplicatedToken = mock(MemberFcmToken.class);
+
+            given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+            given(memberFcmTokenRepository.findByFcmToken(request.fcmToken())).willReturn(Optional.of(duplicatedToken));
+
+            // when
+            memberFcmTokenService.upsertTokenForMember(request, memberId);
+
+            // then
+            then(duplicatedToken).should(times(1)).updateMemberAndDeviceIdentifier(eq(member), eq(request.deviceIdentifier()), any(LocalDateTime.class));
+
+            then(memberFcmTokenRepository).should(times(1)).findByFcmToken(request.fcmToken());
+            then(memberFcmTokenRepository).should(never()).findByMemberAndDeviceIdentifier(any(Member.class), anyString());
+            then(memberFcmTokenRepository).should(never()).save(any(MemberFcmToken.class));
+        }
+
+        @Test
+        @DisplayName("기존 토큰이 존재하면 FCM 토큰을 갱신한다")
+        void upsertTokenForMember_thenExistingToken_updatesFcmToken() {
+            // given
+            Long memberId = 1L;
+            Member member = TestUtils.createEntity(Member.class, Map.of("id", memberId));
+            MemberFcmTokenRequest request = MemberFcmTokenRequest.builder()
+                    .fcmToken("new-fcm-token")
+                    .deviceType("IOS")
+                    .deviceIdentifier("device-123")
+                    .build();
+            MemberFcmToken activeToken = mock(MemberFcmToken.class);
+
+            given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+            given(memberFcmTokenRepository.findByFcmToken(request.fcmToken())).willReturn(Optional.empty());
+            given(memberFcmTokenRepository.findByMemberAndDeviceIdentifier(member, request.deviceIdentifier())).willReturn(Optional.of(activeToken));
+
+            // when
+            memberFcmTokenService.upsertTokenForMember(request, memberId);
+
+            // then
+            then(activeToken).should(times(1)).updateFcmToken(eq(request.fcmToken()), any(LocalDateTime.class));
+
+            then(memberFcmTokenRepository).should(times(1)).findByFcmToken(request.fcmToken());
+            then(memberFcmTokenRepository).should(times(1)).findByMemberAndDeviceIdentifier(member, request.deviceIdentifier());
+            then(memberFcmTokenRepository).should(never()).save(any(MemberFcmToken.class));
+        }
+
+        @Test
+        @DisplayName("토큰이 없다면 신규 토큰을 저장한다")
+        void upsertTokenForMember_thenTokenNotExists_savesNewToken() {
+            // given
+            Long memberId = 1L;
+            Member member = TestUtils.createEntity(Member.class, Map.of("id", memberId));
+            MemberFcmTokenRequest request = MemberFcmTokenRequest.builder()
+                    .fcmToken("fresh-fcm-token")
+                    .deviceType("ANDROID")
+                    .deviceIdentifier("device-123")
+                    .build();
+
+            given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+            given(memberFcmTokenRepository.findByFcmToken(request.fcmToken())).willReturn(Optional.empty());
+            given(memberFcmTokenRepository.findByMemberAndDeviceIdentifier(member, request.deviceIdentifier())).willReturn(Optional.empty());
+            given(memberFcmTokenRepository.save(any(MemberFcmToken.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            memberFcmTokenService.upsertTokenForMember(request, memberId);
+
+            // then
+            ArgumentCaptor<MemberFcmToken> tokenCaptor = ArgumentCaptor.forClass(MemberFcmToken.class);
+            then(memberFcmTokenRepository).should(times(1)).save(tokenCaptor.capture());
+
+            MemberFcmToken savedToken = tokenCaptor.getValue();
+            assertThat(savedToken.getMember()).isEqualTo(member);
+            assertThat(savedToken.getFcmToken()).isEqualTo(request.fcmToken());
+            assertThat(savedToken.getDeviceType()).isEqualTo(request.deviceType());
+            assertThat(savedToken.getDeviceIdentifier()).isEqualTo(request.deviceIdentifier());
+            assertThat(savedToken.getLastUsedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("회원이 존재하지 않으면 예외를 던진다")
+        void upsertTokenForMember_thenMemberNotFound_throwsException() {
+            // given
+            Long memberId = 99L;
+            MemberFcmTokenRequest request = MemberFcmTokenRequest.builder()
+                    .fcmToken("sample-fcm-token")
+                    .deviceType("ANDROID")
+                    .deviceIdentifier("device-123")
+                    .build();
+
+            given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> memberFcmTokenService.upsertTokenForMember(request, memberId))
+                    .isInstanceOf(GlobalException.class)
+                    .hasMessage(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
+
+            then(memberFcmTokenRepository).should(never()).findByFcmToken(anyString());
+            then(memberFcmTokenRepository).should(never()).findByMemberAndDeviceIdentifier(any(Member.class), anyString());
+            then(memberFcmTokenRepository).should(never()).save(any(MemberFcmToken.class));
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 **연관된 이슈**
> close #이슈번호
- close #54 

<br>

## 📝 **작업 내용**

- 토큰 정보를 담을 테이블 생성
- 회원 FCM 토큰 갱신 및 생성 API 구현
- 테스트 코드 작성

<br>

## 📸 **스크린샷 (선택)**

<br>
