### PR TITLE
feat: 사장 매장 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/sparta/couponpop/domain/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/controller/StoreController.java
@@ -4,6 +4,7 @@ import com.sparta.couponpop.common.response.ApiResponse;
 import com.sparta.couponpop.common.security.annotation.CurrentMember;
 import com.sparta.couponpop.common.security.dto.AuthMember;
 import com.sparta.couponpop.domain.store.dto.request.CreateStoreRequest;
+import com.sparta.couponpop.domain.store.dto.response.StoreDetailResponse;
 import com.sparta.couponpop.domain.store.dto.response.StoreResponse;
 import com.sparta.couponpop.domain.store.service.StoreService;
 import jakarta.validation.Valid;
@@ -50,5 +51,13 @@ public class StoreController {
         storeService.deleteStore(storeId, authMember.id());
 
         return ApiResponse.noContent();
+    }
+
+    @GetMapping("/{storeId}")
+    public ResponseEntity<ApiResponse<StoreDetailResponse>> getStoreDetail(@CurrentMember AuthMember authMember, @PathVariable Long storeId) {
+
+        StoreDetailResponse response = storeService.getStoreDetail(storeId, authMember.id());
+
+        return ApiResponse.success(response);
     }
 }

--- a/src/main/java/com/sparta/couponpop/domain/store/dto/response/StoreDetailResponse.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/dto/response/StoreDetailResponse.java
@@ -1,0 +1,36 @@
+package com.sparta.couponpop.domain.store.dto.response;
+
+import com.sparta.couponpop.domain.store.entity.Store;
+import com.sparta.couponpop.domain.store.enums.StoreCategory;
+import lombok.Builder;
+
+import java.time.LocalTime;
+
+@Builder
+public record StoreDetailResponse(
+        String imageUrl,
+        String name,
+        String description,
+        StoreCategory storeCategory,
+        String address,
+        LocalTime weekdayOpenTime,
+        LocalTime weekdayCloseTime,
+        LocalTime weekendOpenTime,
+        LocalTime weekendCloseTime
+) {
+    public static StoreDetailResponse from(Store store) {
+        return StoreDetailResponse.builder()
+                .imageUrl(store.getImageUrl())
+                .name(store.getName())
+                .description(store.getDescription())
+                .storeCategory(store.getStoreCategory())
+                .address(store.getAddress())
+                .weekdayOpenTime(store.getWeekdayOpenTime())
+                .weekdayCloseTime(store.getWeekdayCloseTime())
+                .weekendOpenTime(store.getWeekendOpenTime())
+                .weekendCloseTime(store.getWeekendCloseTime())
+                .build();
+    }
+}
+
+

--- a/src/main/java/com/sparta/couponpop/domain/store/dto/response/StoreDetailResponse.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/dto/response/StoreDetailResponse.java
@@ -2,11 +2,9 @@ package com.sparta.couponpop.domain.store.dto.response;
 
 import com.sparta.couponpop.domain.store.entity.Store;
 import com.sparta.couponpop.domain.store.enums.StoreCategory;
-import lombok.Builder;
 
 import java.time.LocalTime;
 
-@Builder
 public record StoreDetailResponse(
         String imageUrl,
         String name,
@@ -19,17 +17,17 @@ public record StoreDetailResponse(
         LocalTime weekendCloseTime
 ) {
     public static StoreDetailResponse from(Store store) {
-        return StoreDetailResponse.builder()
-                .imageUrl(store.getImageUrl())
-                .name(store.getName())
-                .description(store.getDescription())
-                .storeCategory(store.getStoreCategory())
-                .address(store.getAddress())
-                .weekdayOpenTime(store.getWeekdayOpenTime())
-                .weekdayCloseTime(store.getWeekdayCloseTime())
-                .weekendOpenTime(store.getWeekendOpenTime())
-                .weekendCloseTime(store.getWeekendCloseTime())
-                .build();
+        return new StoreDetailResponse(
+                store.getImageUrl(),
+                store.getName(),
+                store.getDescription(),
+                store.getStoreCategory(),
+                store.getAddress(),
+                store.getWeekdayOpenTime(),
+                store.getWeekdayCloseTime(),
+                store.getWeekendOpenTime(),
+                store.getWeekendCloseTime()
+        );
     }
 }
 

--- a/src/main/java/com/sparta/couponpop/domain/store/exception/StoreErrorCode.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/exception/StoreErrorCode.java
@@ -12,6 +12,7 @@ public enum StoreErrorCode implements ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 회원입니다."),
     STORE_NOT_FOUND(HttpStatus.BAD_REQUEST, "매장을 찾을 수 없습니다."),
     STORE_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 매장입니다."),
+    STORE_ACCESS_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "매장 접근 권한이 없습니다."),
     STORE_UPDATE_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "매장 수정 권한이 없습니다."),
     STORE_DELETE_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "매장 삭제 권한이 없습니다.");
 

--- a/src/main/java/com/sparta/couponpop/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/repository/StoreRepository.java
@@ -19,6 +19,18 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
     @Query(value = "SELECT * FROM stores WHERE id = :storeId", nativeQuery = true)
     Optional<Store> findByIdIncludingDeleted(@Param("storeId") Long storeId);
 
+    /**
+     * 매장과 회원 정보를 함께 조회합니다.
+     * N+1 문제를 방지하기 위해 fetch join을 사용합니다.
+     */
+    @Query("""
+            SELECT s
+            FROM Store s
+            JOIN FETCH s.member m
+            WHERE s.id = :storeId
+            """)
+    Optional<Store> findByIdWithMember(@Param("storeId") Long storeId);
+
     List<Store> findByMemberIdOrderByCreatedAtDesc(Long memberId);
 }
 

--- a/src/main/java/com/sparta/couponpop/domain/store/service/StoreService.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/service/StoreService.java
@@ -112,7 +112,7 @@ public class StoreService {
     @Transactional(readOnly = true)
     public StoreDetailResponse getStoreDetail(Long storeId, Long memberId) {
 
-        Store store = storeRepository.findById(storeId)
+        Store store = storeRepository.findByIdWithMember(storeId)
                 .orElseThrow(() -> new GlobalException(StoreErrorCode.STORE_NOT_FOUND));
 
         if (!store.getMember().getId().equals(memberId)) {

--- a/src/main/java/com/sparta/couponpop/domain/store/service/StoreService.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/service/StoreService.java
@@ -4,6 +4,7 @@ import com.sparta.couponpop.common.exception.GlobalException;
 import com.sparta.couponpop.domain.member.entity.Member;
 import com.sparta.couponpop.domain.member.repository.MemberRepository;
 import com.sparta.couponpop.domain.store.dto.request.CreateStoreRequest;
+import com.sparta.couponpop.domain.store.dto.response.StoreDetailResponse;
 import com.sparta.couponpop.domain.store.dto.response.StoreResponse;
 import com.sparta.couponpop.domain.store.entity.Store;
 import com.sparta.couponpop.domain.store.exception.StoreErrorCode;
@@ -106,5 +107,18 @@ public class StoreService {
         }
 
         store.deleteStore();
+    }
+
+    @Transactional(readOnly = true)
+    public StoreDetailResponse getStoreDetail(Long storeId, Long memberId) {
+
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new GlobalException(StoreErrorCode.STORE_NOT_FOUND));
+
+        if (!store.getMember().getId().equals(memberId)) {
+            throw new GlobalException(StoreErrorCode.STORE_ACCESS_PERMISSION_DENIED);
+        }
+
+        return StoreDetailResponse.from(store);
     }
 }


### PR DESCRIPTION
## 🔗 **연관된 이슈**
> close #이슈번호

Closes #25

<br>

## 📝 **작업 내용**

- 엔드포인트 추가 /api/v1/owner/stores/{storeId}
- 응답: 매장 기본 정보 (이미지, 이름, 설명, 카테고리, 주소, 영업시간)
- 권한: 소유자만 접근 가능

<br>

## 📸 **스크린샷 (선택)**

<br>
