### PR TITLE
refactor: 알림 전송 구조 전략 패턴 도입 및 추상화

### DIFF
--- a/src/main/java/com/sparta/couponpop/domain/member/controller/MemberFcmTokenController.java
+++ b/src/main/java/com/sparta/couponpop/domain/member/controller/MemberFcmTokenController.java
@@ -23,7 +23,7 @@ public class MemberFcmTokenController {
     @PostMapping("/members/fcm-token")
     public ResponseEntity<ApiResponse<Void>> upsertMemberFcmToken(@RequestBody @Valid MemberFcmTokenRequest request, @CurrentMember AuthMember authMember) {
         memberFcmTokenService.upsertTokenForMember(request, authMember.id());
-        return ApiResponse.success(null);
+        return ApiResponse.noContent();
     }
 
 }

--- a/src/main/java/com/sparta/couponpop/domain/notification/config/NotificationConfig.java
+++ b/src/main/java/com/sparta/couponpop/domain/notification/config/NotificationConfig.java
@@ -1,0 +1,24 @@
+package com.sparta.couponpop.domain.notification.config;
+
+import com.sparta.couponpop.domain.notification.dto.command.NotificationCommand;
+import com.sparta.couponpop.domain.notification.enums.NotificationType;
+import com.sparta.couponpop.domain.notification.service.sender.NotificationSender;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Configuration
+public class NotificationConfig {
+
+    @Bean
+    public Map<NotificationType, NotificationSender<? extends NotificationCommand>> notificationSenderRegistry(
+            List<NotificationSender<? extends NotificationCommand>> senders
+    ) {
+        return senders.stream().collect(Collectors.toUnmodifiableMap(NotificationSender::getType, Function.identity()));
+    }
+}
+

--- a/src/main/java/com/sparta/couponpop/domain/notification/constants/NotificationTemplates.java
+++ b/src/main/java/com/sparta/couponpop/domain/notification/constants/NotificationTemplates.java
@@ -1,0 +1,17 @@
+package com.sparta.couponpop.domain.notification.constants;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class NotificationTemplates {
+
+    // 쿠폰 수령 알림 템플릿
+    public static final String COUPON_ISSUED_TITLE = "쿠폰 수령이 완료되었습니다!";
+    public static final String COUPON_ISSUED_BODY = """
+            쿠폰명: %s
+            쿠폰코드: %s
+            만료기간: %s
+            """;
+
+}

--- a/src/main/java/com/sparta/couponpop/domain/notification/dto/command/CouponIssuedNotificationCommand.java
+++ b/src/main/java/com/sparta/couponpop/domain/notification/dto/command/CouponIssuedNotificationCommand.java
@@ -1,0 +1,20 @@
+package com.sparta.couponpop.domain.notification.dto.command;
+
+import com.sparta.couponpop.domain.notification.dto.payload.CouponIssuedNotificationPayload;
+
+/**
+ * 쿠폰 수령 알림 전송 시 필요한 데이터
+ *
+ * @param memberId 회원 PK
+ * @param payload  알림에 포함될 상세 정보
+ */
+public record CouponIssuedNotificationCommand(
+        Long memberId,
+        CouponIssuedNotificationPayload payload
+) implements NotificationCommand {
+
+    public static CouponIssuedNotificationCommand of(Long memberId, CouponIssuedNotificationPayload payload) {
+        return new CouponIssuedNotificationCommand(memberId, payload);
+    }
+}
+

--- a/src/main/java/com/sparta/couponpop/domain/notification/dto/command/LocationBasedCouponEventNotificationCommand.java
+++ b/src/main/java/com/sparta/couponpop/domain/notification/dto/command/LocationBasedCouponEventNotificationCommand.java
@@ -1,0 +1,14 @@
+package com.sparta.couponpop.domain.notification.dto.command;
+
+/**
+ * 위치 기반 쿠폰 이벤트 알림 전송 시 필요한 데이터
+ */
+public record LocationBasedCouponEventNotificationCommand(
+
+) implements NotificationCommand {
+
+    public static LocationBasedCouponEventNotificationCommand of() {
+        return new LocationBasedCouponEventNotificationCommand();
+    }
+}
+

--- a/src/main/java/com/sparta/couponpop/domain/notification/dto/command/NotificationCommand.java
+++ b/src/main/java/com/sparta/couponpop/domain/notification/dto/command/NotificationCommand.java
@@ -1,0 +1,8 @@
+package com.sparta.couponpop.domain.notification.dto.command;
+
+/**
+ * 알림 전송 시 필요한 데이터 타입의 인터페이스
+ */
+public interface NotificationCommand {
+}
+

--- a/src/main/java/com/sparta/couponpop/domain/notification/dto/payload/CouponIssuedNotificationPayload.java
+++ b/src/main/java/com/sparta/couponpop/domain/notification/dto/payload/CouponIssuedNotificationPayload.java
@@ -1,16 +1,22 @@
 package com.sparta.couponpop.domain.notification.dto.payload;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 import java.time.LocalDateTime;
 
 public record CouponIssuedNotificationPayload(
+        @NotBlank(message = "쿠폰명은 필수입니다.")
         String couponName,
+
+        @NotBlank(message = "쿠폰 코드는 필수입니다.")
         String couponCode,
+
+        @NotNull(message = "쿠폰 만료일은 필수입니다.")
         LocalDateTime expireAt
 ) {
 
-    public static CouponIssuedNotificationPayload of(String couponName,
-                                                     String couponCode,
-                                                     LocalDateTime expireAt) {
-        return new CouponIssuedNotificationPayload(couponCode, couponName, expireAt);
+    public static CouponIssuedNotificationPayload of(String couponName, String couponCode, LocalDateTime expireAt) {
+        return new CouponIssuedNotificationPayload(couponName, couponCode, expireAt);
     }
 }

--- a/src/main/java/com/sparta/couponpop/domain/notification/dto/payload/LocationBasedCouponEventNotificationPayload.java
+++ b/src/main/java/com/sparta/couponpop/domain/notification/dto/payload/LocationBasedCouponEventNotificationPayload.java
@@ -1,0 +1,6 @@
+package com.sparta.couponpop.domain.notification.dto.payload;
+
+public record LocationBasedCouponEventNotificationPayload(
+
+) {
+}

--- a/src/main/java/com/sparta/couponpop/domain/notification/enums/NotificationType.java
+++ b/src/main/java/com/sparta/couponpop/domain/notification/enums/NotificationType.java
@@ -1,0 +1,17 @@
+package com.sparta.couponpop.domain.notification.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 알림 유형 ENUM
+ */
+@Getter
+@RequiredArgsConstructor
+public enum NotificationType {
+    COUPON_ISSUED("쿠폰 수령 알림"),
+    LOCATION_BASED_EVENT("위치 기반 이벤트 알림");
+
+    private final String description;
+}
+

--- a/src/main/java/com/sparta/couponpop/domain/notification/exception/NotificationErrorCode.java
+++ b/src/main/java/com/sparta/couponpop/domain/notification/exception/NotificationErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum NotificationErrorCode implements ErrorCode {
 
-    FCM_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "FCM 푸시 알림 전송에 실패했습니다.");
+    FCM_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "FCM 푸시 알림 전송에 실패했습니다."),
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "등록되지 않은 알림 유형입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/sparta/couponpop/domain/notification/factory/FcmMessageFactory.java
+++ b/src/main/java/com/sparta/couponpop/domain/notification/factory/FcmMessageFactory.java
@@ -23,6 +23,23 @@ public class FcmMessageFactory {
     private static final String DATA_KEY_TITLE = "title";
     private static final String DATA_KEY_BODY = "body";
 
+    public Message createMessage(String token, String title, String body) {
+        Notification notification = createNotification(title, body);
+        AndroidConfig androidConfig = createAndroidConfig();
+        ApnsConfig apnsConfig = createApnsConfig();
+        WebpushConfig webpushConfig = createWebpushConfig(title, body);
+
+        return Message.builder()
+                .setToken(token)
+                .setNotification(notification)
+                .setAndroidConfig(androidConfig)
+                .setApnsConfig(apnsConfig)
+                .setWebpushConfig(webpushConfig)
+                .putData(DATA_KEY_TITLE, title)
+                .putData(DATA_KEY_BODY, body)
+                .build();
+    }
+
     public MulticastMessage createMulticastMessage(List<String> tokens, String title, String body) {
         Notification notification = createNotification(title, body);
         AndroidConfig androidConfig = createAndroidConfig();

--- a/src/main/java/com/sparta/couponpop/domain/notification/service/FcmSendService.java
+++ b/src/main/java/com/sparta/couponpop/domain/notification/service/FcmSendService.java
@@ -1,15 +1,12 @@
 package com.sparta.couponpop.domain.notification.service;
 
-import com.google.firebase.messaging.BatchResponse;
-import com.google.firebase.messaging.FirebaseMessaging;
-import com.google.firebase.messaging.FirebaseMessagingException;
-import com.google.firebase.messaging.MulticastMessage;
+import com.google.firebase.messaging.*;
 import com.sparta.couponpop.domain.notification.factory.FcmMessageFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
-import java.util.Collections;
 import java.util.List;
 
 @Slf4j
@@ -22,15 +19,22 @@ public class FcmSendService {
 
     private final FcmMessageFactory fcmMessageFactory;
 
-    public void sendNotification(String token,
-                                 String title,
-                                 String body) throws FirebaseMessagingException {
-        sendNotification(Collections.singletonList(token), title, body);
+    // TODO: 발송된 토큰의 lastUsedAt 업데이트 로직 추가 예정
+    public void sendNotification(String token, String title, String body) throws FirebaseMessagingException {
+        if (!StringUtils.hasText(token)) {
+            log.info("FCM 전송 토큰이 유효하지 않아 전송을 건너뜁니다.");
+            return;
+        }
+
+        Message message = fcmMessageFactory.createMessage(token, title, body);
+        FirebaseMessaging.getInstance().send(message);
+
+        // TODO: 성공 토큰 lastUsedAt 업데이트
+        // TODO: 실패 토큰 삭제 처리
     }
 
-    public void sendNotification(List<String> tokens,
-                                 String title,
-                                 String body) throws FirebaseMessagingException {
+    // TODO: 발송된 토큰의 lastUsedAt 업데이트 로직 추가 예정
+    public void sendNotification(List<String> tokens, String title, String body) throws FirebaseMessagingException {
         if (tokens == null || tokens.isEmpty()) {
             log.info("FCM 전송 토큰이 비어 있어 전송을 건너뜁니다.");
             return;
@@ -45,6 +49,9 @@ public class FcmSendService {
             log.info("[FCM 다건 전송 요청] tokens={}", batch.size());
             BatchResponse response = FirebaseMessaging.getInstance().sendEachForMulticast(message);
             log.info("[FCM 다건 전송 결과] 성공={} 실패={}", response.getSuccessCount(), response.getFailureCount());
+
+            // TODO: 성공 토큰 lastUsedAt 업데이트
+            // TODO: 실패 토큰 삭제 처리
         }
     }
 }

--- a/src/main/java/com/sparta/couponpop/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/sparta/couponpop/domain/notification/service/NotificationService.java
@@ -1,59 +1,51 @@
 package com.sparta.couponpop.domain.notification.service;
 
-import com.google.firebase.messaging.FirebaseMessagingException;
 import com.sparta.couponpop.common.exception.GlobalException;
-import com.sparta.couponpop.domain.member.entity.Member;
-import com.sparta.couponpop.domain.member.entity.MemberFcmToken;
-import com.sparta.couponpop.domain.member.exception.MemberErrorCode;
-import com.sparta.couponpop.domain.member.repository.MemberFcmTokenRepository;
-import com.sparta.couponpop.domain.member.repository.MemberRepository;
+import com.sparta.couponpop.domain.notification.dto.command.CouponIssuedNotificationCommand;
+import com.sparta.couponpop.domain.notification.dto.command.LocationBasedCouponEventNotificationCommand;
+import com.sparta.couponpop.domain.notification.dto.command.NotificationCommand;
 import com.sparta.couponpop.domain.notification.dto.payload.CouponIssuedNotificationPayload;
+import com.sparta.couponpop.domain.notification.enums.NotificationType;
+import com.sparta.couponpop.domain.notification.exception.NotificationErrorCode;
+import com.sparta.couponpop.domain.notification.service.sender.NotificationSender;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.validation.annotation.Validated;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Map;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Validated
 public class NotificationService {
 
-    private final MemberRepository memberRepository;
-    private final MemberFcmTokenRepository memberFcmTokenRepository;
-    private final FcmSendService fcmSendService;
+    private final Map<NotificationType, NotificationSender<? extends NotificationCommand>> senderRegistry;
 
-    public void notifyCustomerCouponIssued(Long memberId, CouponIssuedNotificationPayload payload) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new GlobalException(MemberErrorCode.MEMBER_NOT_FOUND));
-
-        List<MemberFcmToken> enabledTokens = memberFcmTokenRepository.findByMemberAndNotificationEnabledIsTrue(member);
-        if (enabledTokens.isEmpty()) {
-            log.info("푸시 알림이 활성화된 FCM 토큰이 없어 알림을 건너뜁니다. memberId={}", memberId);
-            return;
-        }
-
-        List<String> tokens = enabledTokens.stream()
-                .map(MemberFcmToken::getFcmToken)
-                .collect(Collectors.toList());
-
-        String title = "쿠폰 수령이 완료되었습니다!";
-        String body = """
-                쿠폰명: %s
-                쿠폰코드: %s
-                만료기간: %s
-                """.formatted(
-                payload.couponName(),
-                payload.couponCode(),
-                payload.expireAt()
-        );
-
-        try {
-            fcmSendService.sendNotification(tokens, title, body);
-        } catch (FirebaseMessagingException e) {
-            log.error("FCM 알림 전송 중 오류가 발생했습니다. tokens={}, message={}", tokens, e.getMessage(), e);
-        }
+    public void notifyCustomerCouponIssued(Long memberId, @Valid CouponIssuedNotificationPayload payload) {
+        CouponIssuedNotificationCommand command = CouponIssuedNotificationCommand.of(memberId, payload);
+        execute(NotificationType.COUPON_ISSUED, command);
     }
 
+    public void notifyLocationBasedCouponEvent() {
+        LocationBasedCouponEventNotificationCommand command = LocationBasedCouponEventNotificationCommand.of();
+        execute(NotificationType.LOCATION_BASED_EVENT, command);
+    }
+
+    private <C extends NotificationCommand> void execute(NotificationType type, C command) {
+        NotificationSender<C> sender = findSender(type);
+        sender.send(command);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <C extends NotificationCommand> NotificationSender<C> findSender(NotificationType type) {
+        NotificationSender<? extends NotificationCommand> sender = senderRegistry.get(type);
+        if (sender == null) {
+            log.error("등록되지 않은 알림 유형입니다. type={}, description={}", type, type.getDescription());
+            throw new GlobalException(NotificationErrorCode.NOTIFICATION_NOT_FOUND);
+        }
+        return (NotificationSender<C>) sender;
+    }
 }

--- a/src/main/java/com/sparta/couponpop/domain/notification/service/sender/CouponIssuedNotificationSender.java
+++ b/src/main/java/com/sparta/couponpop/domain/notification/service/sender/CouponIssuedNotificationSender.java
@@ -1,0 +1,73 @@
+package com.sparta.couponpop.domain.notification.service.sender;
+
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.sparta.couponpop.common.exception.GlobalException;
+import com.sparta.couponpop.domain.member.entity.Member;
+import com.sparta.couponpop.domain.member.entity.MemberFcmToken;
+import com.sparta.couponpop.domain.member.exception.MemberErrorCode;
+import com.sparta.couponpop.domain.member.repository.MemberFcmTokenRepository;
+import com.sparta.couponpop.domain.member.repository.MemberRepository;
+import com.sparta.couponpop.domain.notification.dto.command.CouponIssuedNotificationCommand;
+import com.sparta.couponpop.domain.notification.dto.payload.CouponIssuedNotificationPayload;
+import com.sparta.couponpop.domain.notification.enums.NotificationType;
+import com.sparta.couponpop.domain.notification.service.FcmSendService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CouponIssuedNotificationSender implements NotificationSender<CouponIssuedNotificationCommand> {
+
+    private final MemberRepository memberRepository;
+    private final MemberFcmTokenRepository memberFcmTokenRepository;
+    private final FcmSendService fcmSendService;
+
+    @Override
+    public NotificationType getType() {
+        return NotificationType.COUPON_ISSUED;
+    }
+
+    @Override
+    public void send(CouponIssuedNotificationCommand command) {
+        String NotificationTypeDescription = getType().getDescription();
+        Long memberId = command.memberId();
+        CouponIssuedNotificationPayload payload = command.payload();
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GlobalException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        List<MemberFcmToken> enabledTokens = memberFcmTokenRepository.findByMemberAndNotificationEnabledIsTrue(member);
+        if (enabledTokens.isEmpty()) {
+            log.info("푸시 알림이 활성화된 FCM 토큰이 없어 알림을 건너뜁니다. memberId={}", memberId);
+            return;
+        }
+
+        List<String> tokens = enabledTokens.stream()
+                .map(MemberFcmToken::getFcmToken)
+                .distinct()
+                .collect(Collectors.toList());
+
+        String title = "쿠폰 수령이 완료되었습니다!";
+        String body = """
+                쿠폰명: %s
+                쿠폰코드: %s
+                만료기간: %s
+                """.formatted(
+                payload.couponName(),
+                payload.couponCode(),
+                payload.expireAt()
+        );
+
+        try {
+            fcmSendService.sendNotification(tokens, title, body);
+        } catch (FirebaseMessagingException e) {
+            log.error("{} 전송 중 오류가 발생했습니다. tokens={}, message={}", NotificationTypeDescription, tokens, e.getMessage(), e);
+        }
+    }
+}
+

--- a/src/main/java/com/sparta/couponpop/domain/notification/service/sender/CouponIssuedNotificationSender.java
+++ b/src/main/java/com/sparta/couponpop/domain/notification/service/sender/CouponIssuedNotificationSender.java
@@ -7,6 +7,7 @@ import com.sparta.couponpop.domain.member.entity.MemberFcmToken;
 import com.sparta.couponpop.domain.member.exception.MemberErrorCode;
 import com.sparta.couponpop.domain.member.repository.MemberFcmTokenRepository;
 import com.sparta.couponpop.domain.member.repository.MemberRepository;
+import com.sparta.couponpop.domain.notification.constants.NotificationTemplates;
 import com.sparta.couponpop.domain.notification.dto.command.CouponIssuedNotificationCommand;
 import com.sparta.couponpop.domain.notification.dto.payload.CouponIssuedNotificationPayload;
 import com.sparta.couponpop.domain.notification.enums.NotificationType;
@@ -52,12 +53,8 @@ public class CouponIssuedNotificationSender implements NotificationSender<Coupon
                 .distinct()
                 .collect(Collectors.toList());
 
-        String title = "쿠폰 수령이 완료되었습니다!";
-        String body = """
-                쿠폰명: %s
-                쿠폰코드: %s
-                만료기간: %s
-                """.formatted(
+        String title = NotificationTemplates.COUPON_ISSUED_TITLE;
+        String body = NotificationTemplates.COUPON_ISSUED_BODY.formatted(
                 payload.couponName(),
                 payload.couponCode(),
                 payload.expireAt()

--- a/src/main/java/com/sparta/couponpop/domain/notification/service/sender/CouponIssuedNotificationSender.java
+++ b/src/main/java/com/sparta/couponpop/domain/notification/service/sender/CouponIssuedNotificationSender.java
@@ -34,7 +34,7 @@ public class CouponIssuedNotificationSender implements NotificationSender<Coupon
 
     @Override
     public void send(CouponIssuedNotificationCommand command) {
-        String NotificationTypeDescription = getType().getDescription();
+        String notificationTypeDescription = getType().getDescription();
         Long memberId = command.memberId();
         CouponIssuedNotificationPayload payload = command.payload();
 
@@ -66,7 +66,7 @@ public class CouponIssuedNotificationSender implements NotificationSender<Coupon
         try {
             fcmSendService.sendNotification(tokens, title, body);
         } catch (FirebaseMessagingException e) {
-            log.error("{} 전송 중 오류가 발생했습니다. tokens={}, message={}", NotificationTypeDescription, tokens, e.getMessage(), e);
+            log.error("{} 전송 중 오류가 발생했습니다. tokens={}, message={}", notificationTypeDescription, tokens, e.getMessage(), e);
         }
     }
 }

--- a/src/main/java/com/sparta/couponpop/domain/notification/service/sender/LocationBasedCouponEventNotificationSender.java
+++ b/src/main/java/com/sparta/couponpop/domain/notification/service/sender/LocationBasedCouponEventNotificationSender.java
@@ -1,0 +1,31 @@
+package com.sparta.couponpop.domain.notification.service.sender;
+
+import com.sparta.couponpop.domain.member.repository.MemberFcmTokenRepository;
+import com.sparta.couponpop.domain.notification.dto.command.LocationBasedCouponEventNotificationCommand;
+import com.sparta.couponpop.domain.notification.enums.NotificationType;
+import com.sparta.couponpop.domain.notification.service.FcmSendService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LocationBasedCouponEventNotificationSender implements NotificationSender<LocationBasedCouponEventNotificationCommand> {
+
+    private final MemberFcmTokenRepository memberFcmTokenRepository;
+    private final FcmSendService fcmSendService;
+
+    @Override
+    public NotificationType getType() {
+        return NotificationType.LOCATION_BASED_EVENT;
+    }
+
+    // TODO: 위치 기반 알림이니 Webpush는 불필요
+    @Override
+    public void send(LocationBasedCouponEventNotificationCommand command) {
+        String NotificationTypeDescription = getType().getDescription();
+
+    }
+}
+

--- a/src/main/java/com/sparta/couponpop/domain/notification/service/sender/NotificationSender.java
+++ b/src/main/java/com/sparta/couponpop/domain/notification/service/sender/NotificationSender.java
@@ -1,0 +1,17 @@
+package com.sparta.couponpop.domain.notification.service.sender;
+
+import com.sparta.couponpop.domain.notification.dto.command.NotificationCommand;
+import com.sparta.couponpop.domain.notification.enums.NotificationType;
+
+/**
+ * 알림 발송 인터페이스
+ *
+ * @param <C> 알림 실행에 필요한 커맨드 타입
+ */
+public interface NotificationSender<C extends NotificationCommand> {
+
+    NotificationType getType();
+
+    void send(C command);
+}
+

--- a/src/test/java/com/sparta/couponpop/domain/member/controller/MemberFcmTokenControllerTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/member/controller/MemberFcmTokenControllerTest.java
@@ -71,7 +71,7 @@ class MemberFcmTokenControllerTest {
                                 .content(objectMapper.writeValueAsString(request))
                 )
                 .andDo(print())
-                .andExpect(status().isOk());
+                .andExpect(status().isNoContent());
     }
 
 

--- a/src/test/java/com/sparta/couponpop/domain/notification/service/FcmSendServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/notification/service/FcmSendServiceTest.java
@@ -18,10 +18,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.*;
@@ -39,26 +36,30 @@ class FcmSendServiceTest {
     @DisplayName("FCM 알림 발송")
     class SendNotification {
         @Test
-        @DisplayName("단일 토큰 전송 시 멀티캐스트 메시지를 생성한다")
+        @DisplayName("단일 토큰 전송 시 메시지를 생성한다")
         void sendNotification_success_singleToken() throws FirebaseMessagingException {
             // given
             String token = "test-token";
             String title = "알림 제목";
             String body = "알림 내용";
-            given(fcmMessageFactory.createMulticastMessage(anyList(), anyString(), anyString()))
+            given(fcmMessageFactory.createMessage(anyString(), anyString(), anyString()))
                     .willAnswer(invocation -> {
-                        @SuppressWarnings("unchecked")
-                        List<String> requestTokens = new ArrayList<>((List<String>) invocation.getArgument(0, List.class));
+                        String requestToken = invocation.getArgument(0, String.class);
                         String requestTitle = invocation.getArgument(1, String.class);
                         String requestBody = invocation.getArgument(2, String.class);
-                        return buildMessage(requestTokens, requestTitle, requestBody);
+                        return Message.builder()
+                                .setToken(requestToken)
+                                .setNotification(Notification.builder()
+                                        .setTitle(requestTitle)
+                                        .setBody(requestBody)
+                                        .build())
+                                .putData("title", requestTitle)
+                                .putData("body", requestBody)
+                                .build();
                     });
-            FirebaseMessaging firebaseMessaging = mock(FirebaseMessaging.class);
-            BatchResponse batchResponse = mock(BatchResponse.class);
 
-            given(batchResponse.getSuccessCount()).willReturn(1);
-            given(batchResponse.getFailureCount()).willReturn(0);
-            given(firebaseMessaging.sendEachForMulticast(any(MulticastMessage.class))).willReturn(batchResponse);
+            FirebaseMessaging firebaseMessaging = mock(FirebaseMessaging.class);
+            given(firebaseMessaging.send(any(Message.class))).willReturn("mock-message-id");
 
             try (MockedStatic<FirebaseMessaging> mockedStatic = mockStatic(FirebaseMessaging.class)) {
                 mockedStatic.when(FirebaseMessaging::getInstance).thenReturn(firebaseMessaging);
@@ -67,11 +68,11 @@ class FcmSendServiceTest {
                 fcmSendService.sendNotification(token, title, body);
 
                 // then
-                ArgumentCaptor<MulticastMessage> messageCaptor = ArgumentCaptor.forClass(MulticastMessage.class);
-                then(firebaseMessaging).should(times(1)).sendEachForMulticast(messageCaptor.capture());
-                MulticastMessage sentMessage = messageCaptor.getValue();
+                ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
+                then(firebaseMessaging).should(times(1)).send(messageCaptor.capture());
+                Message sentMessage = messageCaptor.getValue();
 
-                assertThat(extractTokens(sentMessage)).containsExactly(token);
+                assertThat(extractToken(sentMessage)).isEqualTo(token);
                 Notification notification = extractNotification(sentMessage);
                 assertThat(extractNotificationValue(notification, "title")).isEqualTo(title);
                 assertThat(extractNotificationValue(notification, "body")).isEqualTo(body);
@@ -163,10 +164,21 @@ class FcmSendServiceTest {
             }
         }
 
-        private Notification extractNotification(MulticastMessage message) {
+        private String extractToken(Message message) {
+            // Message는 Getter를 제공하지 않아 리플렉션으로 토큰을 검증한다.
+            try {
+                Field field = Message.class.getDeclaredField("token");
+                field.setAccessible(true);
+                return (String) field.get(message);
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                throw new IllegalStateException("토큰 정보를 확인할 수 없습니다.", e);
+            }
+        }
+
+        private Notification extractNotification(Message message) {
             // 알림 객체 역시 리플렉션으로 확인한다.
             try {
-                Field field = MulticastMessage.class.getDeclaredField("notification");
+                Field field = Message.class.getDeclaredField("notification");
                 field.setAccessible(true);
                 return (Notification) field.get(message);
             } catch (NoSuchFieldException | IllegalAccessException e) {
@@ -174,8 +186,7 @@ class FcmSendServiceTest {
             }
         }
 
-        private String extractNotificationValue(Notification notification,
-                                                String fieldName) {
+        private String extractNotificationValue(Notification notification, String fieldName) {
             // Notification은 비공개 필드만 노출하므로 리플렉션으로 값을 읽는다.
             try {
                 Field field = Notification.class.getDeclaredField(fieldName);

--- a/src/test/java/com/sparta/couponpop/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/notification/service/NotificationServiceTest.java
@@ -1,207 +1,90 @@
 package com.sparta.couponpop.domain.notification.service;
 
-import com.google.firebase.messaging.FirebaseMessagingException;
 import com.sparta.couponpop.common.exception.GlobalException;
-import com.sparta.couponpop.domain.member.entity.Member;
-import com.sparta.couponpop.domain.member.entity.MemberFcmToken;
-import com.sparta.couponpop.domain.member.enums.MemberType;
-import com.sparta.couponpop.domain.member.exception.MemberErrorCode;
-import com.sparta.couponpop.domain.member.repository.MemberFcmTokenRepository;
-import com.sparta.couponpop.domain.member.repository.MemberRepository;
+import com.sparta.couponpop.domain.notification.dto.command.CouponIssuedNotificationCommand;
+import com.sparta.couponpop.domain.notification.dto.command.LocationBasedCouponEventNotificationCommand;
+import com.sparta.couponpop.domain.notification.dto.command.NotificationCommand;
 import com.sparta.couponpop.domain.notification.dto.payload.CouponIssuedNotificationPayload;
+import com.sparta.couponpop.domain.notification.enums.NotificationType;
+import com.sparta.couponpop.domain.notification.exception.NotificationErrorCode;
+import com.sparta.couponpop.domain.notification.service.sender.NotificationSender;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
+import java.util.EnumMap;
+import java.util.Map;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.then;
 
 @ExtendWith(MockitoExtension.class)
 class NotificationServiceTest {
 
-    @InjectMocks
-    private NotificationService notificationService;
+    @Mock
+    private NotificationSender<CouponIssuedNotificationCommand> couponIssuedNotificationSender;
 
     @Mock
-    private MemberRepository memberRepository;
-
-    @Mock
-    private MemberFcmTokenRepository memberFcmTokenRepository;
-
-    @Mock
-    private FcmSendService fcmSendService;
+    private NotificationSender<LocationBasedCouponEventNotificationCommand> locationBasedCouponEventNotificationSender;
 
     @Nested
-    @DisplayName("손님 쿠폰 수령 알림 전송")
+    @DisplayName("손님 쿠폰 수령 알림")
     class NotifyCustomerCouponIssued {
+
+        private Map<NotificationType, NotificationSender<? extends NotificationCommand>> registry;
+        private NotificationService notificationService;
+
+        @BeforeEach
+        void setUp() {
+            registry = new EnumMap<>(NotificationType.class);
+            notificationService = new NotificationService(registry);
+        }
+
         @Test
-        @DisplayName("회원이 존재하지 않으면 예외를 던진다")
-        void notifyCustomerCouponIssued_fail_memberNotFound() throws FirebaseMessagingException {
+        @DisplayName("쿠폰 수령 알림 전송 시 등록된 Sender로 위임한다")
+        void notifyCustomerCouponIssued_success_delegateToRegisteredSender() {
             // given
             Long memberId = 1L;
             CouponIssuedNotificationPayload payload = CouponIssuedNotificationPayload.of(
                     "아메리카노 1+1",
                     "Coupon-123",
-                    LocalDateTime.of(2024, 3, 1, 10, 0)
+                    LocalDateTime.of(2024, 7, 1, 12, 30)
             );
-            given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+            registry.put(NotificationType.COUPON_ISSUED, couponIssuedNotificationSender);
+            ArgumentCaptor<CouponIssuedNotificationCommand> commandCaptor = ArgumentCaptor.forClass(CouponIssuedNotificationCommand.class);
 
-            // when & then
-            assertThatThrownBy(() -> notificationService.notifyCustomerCouponIssued(memberId, payload))
-                    .isInstanceOf(GlobalException.class)
-                    .extracting("errorCode")
-                    .isEqualTo(MemberErrorCode.MEMBER_NOT_FOUND);
+            // when
+            notificationService.notifyCustomerCouponIssued(memberId, payload);
 
-            then(memberFcmTokenRepository).should(never()).findByMemberAndNotificationEnabledIsTrue(any(Member.class));
-            then(fcmSendService).should(never()).sendNotification(anyList(), anyString(), anyString());
+            // then
+            then(couponIssuedNotificationSender).should().send(commandCaptor.capture());
+            CouponIssuedNotificationCommand command = commandCaptor.getValue();
+            assertThat(command.memberId()).isEqualTo(memberId);
+            assertThat(command.payload()).isEqualTo(payload);
         }
 
         @Test
-        @DisplayName("푸시 알림이 비활성화되면 FCM 전송을 시도하지 않는다")
-        void notifyCustomerCouponIssued_skipSend_notificationsDisabled() throws FirebaseMessagingException {
+        @DisplayName("등록되지 않은 알림 유형이면 예외를 던진다")
+        void notifyCustomerCouponIssued_fail_senderNotFound() {
             // given
-            Long memberId = 2L;
-            Member member = Member.signUp(
-                    "customer@test.com",
-                    "손님",
-                    "hashedPassword",
-                    "010-0000-0000",
-                    MemberType.CUSTOMER
-            );
             CouponIssuedNotificationPayload payload = CouponIssuedNotificationPayload.of(
                     "아메리카노 1+1",
                     "Coupon-123",
                     LocalDateTime.of(2024, 7, 1, 12, 30)
             );
-            given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-            given(memberFcmTokenRepository.findByMemberAndNotificationEnabledIsTrue(member)).willReturn(List.of());
-
-            // when
-            notificationService.notifyCustomerCouponIssued(memberId, payload);
-
-            // then
-            then(memberFcmTokenRepository).should().findByMemberAndNotificationEnabledIsTrue(member);
-            then(fcmSendService).should(never()).sendNotification(anyList(), anyString(), anyString());
-        }
-
-        @Test
-        @DisplayName("알림이 활성화된 모든 기기에 FCM을 전송한다")
-        void notifyCustomerCouponIssued_success_notificationsEnabled() throws FirebaseMessagingException {
-            // given
-            Long memberId = 3L;
-            Member member = Member.signUp(
-                    "active@test.com",
-                    "활성회원",
-                    "hashedPassword",
-                    "010-1111-2222",
-                    MemberType.CUSTOMER
-            );
-            MemberFcmToken token1 = MemberFcmToken.of(
-                    member,
-                    "token-A",
-                    "android",
-                    "device-1",
-                    true,
-                    LocalDateTime.now()
-            );
-            MemberFcmToken token2 = MemberFcmToken.of(
-                    member,
-                    "token-B",
-                    "ios",
-                    "device-2",
-                    true,
-                    LocalDateTime.now()
-            );
-            LocalDateTime expireAt = LocalDateTime.of(2024, 9, 10, 18, 45);
-            CouponIssuedNotificationPayload payload = CouponIssuedNotificationPayload.of(
-                    "아메리카노 1+1",
-                    "Coupon-123",
-                    expireAt
-            );
-            given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-            given(memberFcmTokenRepository.findByMemberAndNotificationEnabledIsTrue(member)).willReturn(List.of(token1, token2));
-
-            // when
-            notificationService.notifyCustomerCouponIssued(memberId, payload);
-
-            // then
-            @SuppressWarnings("unchecked")
-            ArgumentCaptor<List<String>> tokensCaptor = ArgumentCaptor.forClass(List.class);
-            ArgumentCaptor<String> titleCaptor = ArgumentCaptor.forClass(String.class);
-            ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
-
-            then(fcmSendService).should().sendNotification(
-                    tokensCaptor.capture(),
-                    titleCaptor.capture(),
-                    bodyCaptor.capture()
-            );
-
-            String expectedBody = """
-                    쿠폰명: %s
-                    쿠폰코드: %s
-                    만료기간: %s
-                    """.formatted(
-                    payload.couponName(),
-                    payload.couponCode(),
-                    expireAt
-            );
-
-            assertThat(tokensCaptor.getValue()).containsExactly("token-A", "token-B");
-            assertThat(titleCaptor.getValue()).isEqualTo("쿠폰 수령이 완료되었습니다!");
-            assertThat(bodyCaptor.getValue()).isEqualTo(expectedBody);
-        }
-
-        @Test
-        @DisplayName("FCM 전송에 실패해도 예외를 전파하지 않는다")
-        void notifyCustomerCouponIssued_ignoreException_fcmSendFails() throws FirebaseMessagingException {
-            // given
-            Long memberId = 4L;
-            Member member = Member.signUp(
-                    "failure@test.com",
-                    "실패회원",
-                    "hashedPassword",
-                    "010-3333-4444",
-                    MemberType.CUSTOMER
-            );
-            MemberFcmToken token = MemberFcmToken.of(
-                    member,
-                    "token-FAIL",
-                    "web",
-                    "device-3",
-                    true,
-                    LocalDateTime.now()
-            );
-            CouponIssuedNotificationPayload payload = CouponIssuedNotificationPayload.of(
-                    "아메리카노 1+1",
-                    "Coupon-123",
-                    LocalDateTime.of(2024, 10, 5, 20, 0)
-            );
-            given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-            given(memberFcmTokenRepository.findByMemberAndNotificationEnabledIsTrue(member))
-                    .willReturn(List.of(token));
-
-            FirebaseMessagingException messagingException = mock(FirebaseMessagingException.class);
-            willThrow(messagingException).given(fcmSendService)
-                    .sendNotification(anyList(), anyString(), anyString());
 
             // when & then
-            assertThatCode(() -> notificationService.notifyCustomerCouponIssued(memberId, payload))
-                    .doesNotThrowAnyException();
-
-            then(fcmSendService).should().sendNotification(anyList(), eq("쿠폰 수령이 완료되었습니다!"), anyString());
+            assertThatThrownBy(() -> notificationService.notifyCustomerCouponIssued(1L, payload))
+                    .isInstanceOf(GlobalException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(NotificationErrorCode.NOTIFICATION_NOT_FOUND);
         }
     }
-
 }

--- a/src/test/java/com/sparta/couponpop/domain/notification/service/sender/CouponIssuedNotificationSenderTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/notification/service/sender/CouponIssuedNotificationSenderTest.java
@@ -1,0 +1,231 @@
+package com.sparta.couponpop.domain.notification.service.sender;
+
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.sparta.couponpop.common.exception.GlobalException;
+import com.sparta.couponpop.domain.member.entity.Member;
+import com.sparta.couponpop.domain.member.entity.MemberFcmToken;
+import com.sparta.couponpop.domain.member.enums.MemberType;
+import com.sparta.couponpop.domain.member.exception.MemberErrorCode;
+import com.sparta.couponpop.domain.member.repository.MemberFcmTokenRepository;
+import com.sparta.couponpop.domain.member.repository.MemberRepository;
+import com.sparta.couponpop.domain.notification.dto.command.CouponIssuedNotificationCommand;
+import com.sparta.couponpop.domain.notification.dto.payload.CouponIssuedNotificationPayload;
+import com.sparta.couponpop.domain.notification.service.FcmSendService;
+import com.sparta.couponpop.utils.TestUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class CouponIssuedNotificationSenderTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private MemberFcmTokenRepository memberFcmTokenRepository;
+
+    @Mock
+    private FcmSendService fcmSendService;
+
+    @InjectMocks
+    private CouponIssuedNotificationSender sender;
+
+    @Nested
+    @DisplayName("손님 쿠폰 수령 알림 전송")
+    class Send {
+
+        @Test
+        @DisplayName("회원이 존재하지 않으면 예외를 던진다")
+        void send_fail_memberNotFound() {
+            // given
+            Long memberId = 1L;
+            CouponIssuedNotificationCommand command = CouponIssuedNotificationCommand.of(
+                    memberId,
+                    CouponIssuedNotificationPayload.of(
+                            "아메리카노 1+1",
+                            "Coupon-123",
+                            LocalDateTime.of(2024, 3, 1, 10, 0)
+                    )
+            );
+            given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> sender.send(command))
+                    .isInstanceOf(GlobalException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(MemberErrorCode.MEMBER_NOT_FOUND);
+
+            then(memberFcmTokenRepository).shouldHaveNoInteractions();
+            then(fcmSendService).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("푸시 알림이 비활성화되면 FCM 전송을 시도하지 않는다")
+        void send_skipSend_notificationsDisabled() throws FirebaseMessagingException {
+            // given
+            Long memberId = 2L;
+            Member member = TestUtils.createEntity(Member.class, Map.of(
+                    "id", memberId,
+                    "email", "customer@test.com",
+                    "username", "손님",
+                    "password", "hashedPassword",
+                    "phoneNumber", "010-0000-0000",
+                    "memberType", MemberType.CUSTOMER
+            ));
+            CouponIssuedNotificationCommand command = CouponIssuedNotificationCommand.of(
+                    memberId,
+                    CouponIssuedNotificationPayload.of(
+                            "아메리카노 1+1",
+                            "Coupon-123",
+                            LocalDateTime.of(2024, 7, 1, 12, 30)
+                    )
+            );
+            given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+            given(memberFcmTokenRepository.findByMemberAndNotificationEnabledIsTrue(member)).willReturn(List.of());
+
+            // when
+            sender.send(command);
+
+            // then
+            then(memberFcmTokenRepository).should().findByMemberAndNotificationEnabledIsTrue(member);
+            then(fcmSendService).should(never()).sendNotification(anyList(), anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("알림이 활성화된 모든 기기에 중복 없이 FCM을 전송한다")
+        void send_success_notificationsEnabled() throws FirebaseMessagingException {
+            // given
+            Long memberId = 3L;
+            Member member = TestUtils.createEntity(Member.class, Map.of(
+                    "id", memberId,
+                    "email", "active@test.com",
+                    "username", "활성회원",
+                    "password", "hashedPassword",
+                    "phoneNumber", "010-1111-2222",
+                    "memberType", MemberType.CUSTOMER
+            ));
+            MemberFcmToken token1 = MemberFcmToken.of(
+                    member,
+                    "token-A",
+                    "android",
+                    "device-1",
+                    true,
+                    LocalDateTime.now()
+            );
+            MemberFcmToken token2 = MemberFcmToken.of(
+                    member,
+                    "token-B",
+                    "ios",
+                    "device-2",
+                    true,
+                    LocalDateTime.now()
+            );
+            MemberFcmToken duplicateToken = MemberFcmToken.of(
+                    member,
+                    "token-A",
+                    "web",
+                    "device-3",
+                    true,
+                    LocalDateTime.now()
+            );
+            LocalDateTime expireAt = LocalDateTime.of(2024, 9, 10, 18, 45);
+            CouponIssuedNotificationCommand command = CouponIssuedNotificationCommand.of(
+                    memberId,
+                    CouponIssuedNotificationPayload.of(
+                            "아메리카노 1+1",
+                            "Coupon-123",
+                            expireAt
+                    )
+            );
+            given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+            given(memberFcmTokenRepository.findByMemberAndNotificationEnabledIsTrue(member))
+                    .willReturn(List.of(token1, token2, duplicateToken));
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<List<String>> tokensCaptor = ArgumentCaptor.forClass(List.class);
+            ArgumentCaptor<String> titleCaptor = ArgumentCaptor.forClass(String.class);
+            ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+
+            // when
+            sender.send(command);
+
+            // then
+            then(fcmSendService).should().sendNotification(
+                    tokensCaptor.capture(),
+                    titleCaptor.capture(),
+                    bodyCaptor.capture()
+            );
+
+            String expectedBody = """
+                    쿠폰명: %s
+                    쿠폰코드: %s
+                    만료기간: %s
+                    """.formatted(
+                    command.payload().couponName(),
+                    command.payload().couponCode(),
+                    expireAt
+            );
+
+            assertThat(tokensCaptor.getValue()).containsExactlyInAnyOrder("token-A", "token-B");
+            assertThat(titleCaptor.getValue()).isEqualTo("쿠폰 수령이 완료되었습니다!");
+            assertThat(bodyCaptor.getValue()).isEqualTo(expectedBody);
+        }
+
+        @Test
+        @DisplayName("FCM 전송에 실패해도 예외를 전파하지 않는다")
+        void send_ignoreException_fcmSendFails() throws FirebaseMessagingException {
+            // given
+            Long memberId = 4L;
+            Member member = TestUtils.createEntity(Member.class, Map.of(
+                    "id", memberId,
+                    "email", "failure@test.com",
+                    "username", "실패회원",
+                    "password", "hashedPassword",
+                    "phoneNumber", "010-3333-4444",
+                    "memberType", MemberType.CUSTOMER
+            ));
+            MemberFcmToken token = MemberFcmToken.of(
+                    member,
+                    "token-FAIL",
+                    "web",
+                    "device-3",
+                    true,
+                    LocalDateTime.now()
+            );
+            CouponIssuedNotificationCommand command = CouponIssuedNotificationCommand.of(
+                    memberId,
+                    CouponIssuedNotificationPayload.of(
+                            "아메리카노 1+1",
+                            "Coupon-123",
+                            LocalDateTime.of(2024, 10, 5, 20, 0)
+                    )
+            );
+            given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+            given(memberFcmTokenRepository.findByMemberAndNotificationEnabledIsTrue(member)).willReturn(List.of(token));
+
+            FirebaseMessagingException messagingException = mock(FirebaseMessagingException.class);
+            willThrow(messagingException).given(fcmSendService).sendNotification(anyList(), anyString(), anyString());
+
+            // when & then
+            assertThatCode(() -> sender.send(command)).doesNotThrowAnyException();
+        }
+    }
+}

--- a/src/test/java/com/sparta/couponpop/domain/notification/service/sender/CouponIssuedNotificationSenderTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/notification/service/sender/CouponIssuedNotificationSenderTest.java
@@ -8,6 +8,7 @@ import com.sparta.couponpop.domain.member.enums.MemberType;
 import com.sparta.couponpop.domain.member.exception.MemberErrorCode;
 import com.sparta.couponpop.domain.member.repository.MemberFcmTokenRepository;
 import com.sparta.couponpop.domain.member.repository.MemberRepository;
+import com.sparta.couponpop.domain.notification.constants.NotificationTemplates;
 import com.sparta.couponpop.domain.notification.dto.command.CouponIssuedNotificationCommand;
 import com.sparta.couponpop.domain.notification.dto.payload.CouponIssuedNotificationPayload;
 import com.sparta.couponpop.domain.notification.service.FcmSendService;
@@ -174,18 +175,14 @@ class CouponIssuedNotificationSenderTest {
                     bodyCaptor.capture()
             );
 
-            String expectedBody = """
-                    쿠폰명: %s
-                    쿠폰코드: %s
-                    만료기간: %s
-                    """.formatted(
+            String expectedBody = NotificationTemplates.COUPON_ISSUED_BODY.formatted(
                     command.payload().couponName(),
                     command.payload().couponCode(),
                     expireAt
             );
 
             assertThat(tokensCaptor.getValue()).containsExactlyInAnyOrder("token-A", "token-B");
-            assertThat(titleCaptor.getValue()).isEqualTo("쿠폰 수령이 완료되었습니다!");
+            assertThat(titleCaptor.getValue()).isEqualTo(NotificationTemplates.COUPON_ISSUED_TITLE);
             assertThat(bodyCaptor.getValue()).isEqualTo(expectedBody);
         }
 


### PR DESCRIPTION
## 🔗 **연관된 이슈**
> close #이슈번호
- close #70 

<br>

## 📝 **작업 내용**

- 알림 유형별 `NotificationSender` 레지스트리 빈 추가
- 공통 Command 인터페이스
- 알림 유형 ENUM 정의
- 단일 토큰 전송용 `Message` 생성 메서드 추가 (불필요한 오버헤드 방지)
- `NotificationService` Sender 레지스트리 기반 위임 구조 개편
- `Payload` Bean Validation 추가
- 테스트코드 작성

<br>

## 📸 **스크린샷 (선택)**

<br>
