### PR TITLE
fix: 1차 예외 처리 요청이 무시되고, 인증 예외로 덮어써지는 현상 수정

### DIFF
--- a/src/main/java/com/sparta/couponpop/common/security/JwtAuthFilter.java
+++ b/src/main/java/com/sparta/couponpop/common/security/JwtAuthFilter.java
@@ -58,14 +58,17 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             log.debug("[JwtFilter] 인증 실패: 만료된 토큰 - {}", e.getMessage());
             handlerExceptionResolver.resolveException(request, response, null,
                     new GlobalException(AuthErrorCode.EXPIRED_TOKEN));
+            return;
         } catch (MalformedJwtException | SignatureException e) { // 토큰의 형식이 올바르지 않은 경우, 토큰의 시그니처가 올바르지 않은 경우
             log.debug("[JwtFilter] 인증 실패: 유효하지 않은 토큰 - {}", e.getMessage());
             handlerExceptionResolver.resolveException(request, response, null,
                     new GlobalException(AuthErrorCode.INVALID_TOKEN));
+            return;
         } catch (Exception e) {
             log.debug("[JwtFilter] 인증 실패: 토큰 인증 과정 중 다른 오류 발생 - {}", e.getMessage());
             handlerExceptionResolver.resolveException(request, response, null,
                     new GlobalException(CommonErrorCode.INTERNAL_SERVER_ERROR));
+            return;
         }
 
         chain.doFilter(request, response);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,6 +32,7 @@ jwt:
       - /api/v1/auth/signup
       - /api/v1/auth/login
       - /actuator/health
+      - /error
 
 fcm:
   firebase-config-path: "classpath:firebase/serviceAccountKey.json"


### PR DESCRIPTION
## 🔗 **연관된 이슈**
> close #73 

<br>

## 📝 **작업 내용**

- 화이트리스트에 1차 예외 처리의 내부 엔드포인트인 /error를  추가
- JwtAuthFilter에서 catch된 exception이 또 filterChain을 타지 않도록 catch 블록에 return; 추가

<br>

- 차후에 현재의 GlobalExceptionHandler에서 담당하는 일원화된 예외 처리를 이원화로 분리 검토
  - FilterLevel을 exceptionHandling을 전담하는 FilterExceptionHandlingFilter 도입
