### PR TITLE
feat: 손님 매장 검색 API 구현

### DIFF
--- a/src/main/java/com/sparta/couponpop/domain/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/controller/StoreController.java
@@ -80,4 +80,12 @@ public class StoreController {
 
         return ApiResponse.success(response);
     }
+
+    @GetMapping("/stores/search")
+    public ResponseEntity<ApiResponse<List<StoreResponse>>> searchStores(@RequestParam String keyword) {
+
+        List<StoreResponse> stores = storeService.searchStoresByName(keyword);
+
+        return ApiResponse.success(stores);
+    }
 }

--- a/src/main/java/com/sparta/couponpop/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/repository/StoreRepository.java
@@ -73,6 +73,6 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
      * 매장명으로 매장을 검색합니다.
      * 삭제되지 않은 매장 중에서 매장명에 키워드가 포함된 매장을 조회합니다
      */
-    @Query("SELECT s FROM Store s WHERE s.name LIKE %:keyword% ORDER BY s.name ASC")
+    @Query("SELECT s FROM Store s WHERE LOWER(s.name) LIKE LOWER(CONCAT('%', :keyword, '%')) ORDER BY s.name ASC")
     List<Store> findByNameContainingIgnoreCase(@Param("keyword") String keyword);
 }

--- a/src/main/java/com/sparta/couponpop/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/repository/StoreRepository.java
@@ -68,4 +68,11 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
                                               @Param("radius") double radiusKm);
 
     List<Store> findByMemberIdOrderByCreatedAtDesc(Long memberId);
+
+    /**
+     * 매장명으로 매장을 검색합니다.
+     * 삭제되지 않은 매장 중에서 매장명에 키워드가 포함된 매장을 조회합니다
+     */
+    @Query("SELECT s FROM Store s WHERE s.name LIKE %:keyword% ORDER BY s.name ASC")
+    List<Store> findByNameContainingIgnoreCase(@Param("keyword") String keyword);
 }

--- a/src/main/java/com/sparta/couponpop/domain/store/service/StoreService.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/service/StoreService.java
@@ -134,6 +134,16 @@ public class StoreService {
     }
 
     @Transactional(readOnly = true)
+    public List<StoreResponse> searchStoresByName(String keyword) {
+
+        List<Store> stores = storeRepository.findByNameContainingIgnoreCase(keyword);
+
+        return stores.stream()
+                .map(StoreResponse::from)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
     public List<StoreMapResponse> getStoresByLocation(double latitude, double longitude, double radiusKm) {
 
         return storeRepository.findByLocation(latitude, longitude, radiusKm)

--- a/src/test/java/com/sparta/couponpop/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/store/service/StoreServiceTest.java
@@ -836,4 +836,50 @@ class StoreServiceTest {
 
         then(storeRepository).should(times(1)).findById(storeId);
     }
+
+    @Test
+    @DisplayName("매장명 검색 성공")
+    void searchStoresByName_Success() {
+
+        // given
+        String keyword = "스타벅스";
+        Member member1 = createMember(1L);
+        Member member2 = createMember(2L);
+        
+        Store store1 = createStore(member1);
+        Store store2 = createCafeStore(member2);
+        List<Store> stores = Arrays.asList(store1, store2);
+
+        given(storeRepository.findByNameContainingIgnoreCase(keyword))
+                .willReturn(stores);
+
+        // when
+        List<StoreResponse> result = storeService.searchStoresByName(keyword);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).name()).isEqualTo(store1.getName());
+        assertThat(result.get(1).name()).isEqualTo(store2.getName());
+
+        then(storeRepository).should(times(1)).findByNameContainingIgnoreCase(keyword);
+    }
+
+    @Test
+    @DisplayName("매장명 검색 - 검색 결과 없음")
+    void searchStoresByName_NoResults_ReturnsEmptyList() {
+
+        // given
+        String keyword = "존재하지않는매장";
+
+        given(storeRepository.findByNameContainingIgnoreCase(keyword))
+                .willReturn(Arrays.asList());
+
+        // when
+        List<StoreResponse> result = storeService.searchStoresByName(keyword);
+
+        // then
+        assertThat(result).isEmpty();
+
+        then(storeRepository).should(times(1)).findByNameContainingIgnoreCase(keyword);
+    }
 }


### PR DESCRIPTION
## 🔗 **연관된 이슈**
> close #이슈번호

Closes #29 
<br>

## 📝 **작업 내용**

- /api/v1/stores/search?keyword=검색어 엔드포인트 추가
- 매장명에 키워드가 포함된 매장들을 검색 (대소문자 구분 없음)
- 삭제되지 않은 매장만 검색
- 매장명 순으로 정렬하여 반환

<br>

## 📸 **스크린샷 (선택)**

<br>
