### PR TITLE
feat : 쿠폰 정보 상제 조회 API

### DIFF
--- a/src/main/java/com/sparta/couponpop/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/sparta/couponpop/domain/coupon/controller/CouponController.java
@@ -4,14 +4,12 @@ import com.sparta.couponpop.common.response.ApiResponse;
 import com.sparta.couponpop.common.security.annotation.CurrentMember;
 import com.sparta.couponpop.common.security.dto.AuthMember;
 import com.sparta.couponpop.domain.coupon.dto.request.CouponIssueRequest;
+import com.sparta.couponpop.domain.coupon.dto.response.CouponDetailResponse;
 import com.sparta.couponpop.domain.coupon.service.CouponService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
 
@@ -27,5 +25,11 @@ public class CouponController {
         LocalDateTime issuedTime = LocalDateTime.now();
         couponService.issueEventCoupon(authMember.id(), request.storeId(), request.eventId(), issuedTime);
         return ApiResponse.noContent();
+    }
+
+    @GetMapping("/coupons/{couponId}")
+    public ResponseEntity<ApiResponse<CouponDetailResponse>> getCouponDetail(@PathVariable Long couponId, @CurrentMember AuthMember authMember) {
+        CouponDetailResponse response = couponService.getCouponDetail(couponId, authMember.id());
+        return ApiResponse.success(response);
     }
 }

--- a/src/main/java/com/sparta/couponpop/domain/coupon/dto/response/CouponDetailResponse.java
+++ b/src/main/java/com/sparta/couponpop/domain/coupon/dto/response/CouponDetailResponse.java
@@ -28,7 +28,7 @@ public record CouponDetailResponse(
                 coupon.getReceivedAt(),
                 coupon.getExpireAt(),
                 coupon.getUsedAt(),
-                tempCode.map(code -> new QrCode("https://couponpop.com/q/" + tempCode, "사장님께 QR코드를 보여주세요"))
+                tempCode.map(code -> new QrCode("https://couponpop.com/q/" + code, "사장님께 QR코드를 보여주세요"))
                         .orElse(null),
                 EventInfo.from(coupon.getCouponEvent()),
                 StoreInfo.from(coupon.getCouponEvent().getStore())

--- a/src/main/java/com/sparta/couponpop/domain/coupon/dto/response/CouponDetailResponse.java
+++ b/src/main/java/com/sparta/couponpop/domain/coupon/dto/response/CouponDetailResponse.java
@@ -1,0 +1,57 @@
+package com.sparta.couponpop.domain.coupon.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.sparta.couponpop.domain.coupon.entity.Coupon;
+import com.sparta.couponpop.domain.coupon.enums.CouponStatus;
+import com.sparta.couponpop.domain.couponevent.entity.CouponEvent;
+import com.sparta.couponpop.domain.store.entity.Store;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+
+public record CouponDetailResponse(
+        Long id,
+        CouponStatus status,
+        LocalDateTime issuedAt,
+        LocalDateTime expireAt,
+        LocalDateTime usedAt,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        QrCode qrCode,
+        EventInfo event,
+        StoreInfo store
+) {
+    public static CouponDetailResponse from(Coupon coupon, Optional<String> tempCode) {
+        return new CouponDetailResponse(
+                coupon.getId(),
+                coupon.getCouponStatus(),
+                coupon.getReceivedAt(),
+                coupon.getExpireAt(),
+                coupon.getUsedAt(),
+                tempCode.map(code -> new QrCode("https://couponpop.com/q/" + tempCode, "사장님께 QR코드를 보여주세요"))
+                        .orElse(null),
+                EventInfo.from(coupon.getCouponEvent()),
+                StoreInfo.from(coupon.getCouponEvent().getStore())
+        );
+    }
+
+    public record QrCode(String url, String message) {
+    }
+
+
+    public record EventInfo(Long id, String name, EventPeriod period) {
+        public static EventInfo from(CouponEvent event) {
+            return new EventInfo(event.getId(), event.getName(),
+                    new EventPeriod(event.getEventStartAt(), event.getEventEndAt()));
+        }
+
+        public record EventPeriod(LocalDateTime startAt, LocalDateTime endAt) {
+        }
+    }
+
+    public record StoreInfo(Long id, String name, String address, String phone) {
+        public static StoreInfo from(Store store) {
+            return new StoreInfo(store.getId(), store.getName(), store.getAddress(), store.getPhone());
+        }
+    }
+}

--- a/src/main/java/com/sparta/couponpop/domain/coupon/entity/Coupon.java
+++ b/src/main/java/com/sparta/couponpop/domain/coupon/entity/Coupon.java
@@ -32,6 +32,8 @@ public class Coupon extends BaseEntity {
 
     private LocalDateTime receivedAt;
 
+    private LocalDateTime expireAt;
+
     private LocalDateTime usedAt;
 
     @Enumerated(EnumType.STRING)
@@ -69,6 +71,10 @@ public class Coupon extends BaseEntity {
 
     private static String generateCouponCode() {
         return "CPN-" + java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 12).toUpperCase();
+    }
+
+    public boolean isAvailable() {
+        return CouponStatus.AVAILABLE.equals(this.couponStatus);
     }
 
     public boolean isUsed() {

--- a/src/main/java/com/sparta/couponpop/domain/coupon/exception/CouponErrorCode.java
+++ b/src/main/java/com/sparta/couponpop/domain/coupon/exception/CouponErrorCode.java
@@ -9,7 +9,10 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum CouponErrorCode implements ErrorCode {
 
-    COUPON_ALREADY_ISSUED(HttpStatus.BAD_REQUEST, "해당 쿠폰은 이미 발급되었습니다.");
+    COUPON_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 쿠폰에 접근할 수 없습니다."),
+
+    COUPON_ALREADY_ISSUED(HttpStatus.BAD_REQUEST, "해당 쿠폰은 이미 발급되었습니다."),
+    COUPON_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않은 쿠폰입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/sparta/couponpop/domain/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/sparta/couponpop/domain/coupon/repository/CouponRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
+
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
 
     @Query("""
@@ -16,4 +18,13 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
     int countByEventIdAndStatus(@Param("eventId") Long eventId, @Param("status") CouponStatus status);
 
     boolean existsByMemberIdAndCouponEventId(Long memberId, Long eventId);
+
+    @Query("""
+            select c
+            from Coupon c
+                join fetch c.couponEvent ce
+                join fetch ce.store s
+            where c.id = :couponId
+            """)
+    Optional<Coupon> findByIdWithCouponEventAndStore(@Param("couponId") Long couponId);
 }

--- a/src/main/java/com/sparta/couponpop/domain/coupon/repository/TemporaryCouponCodeRepository.java
+++ b/src/main/java/com/sparta/couponpop/domain/coupon/repository/TemporaryCouponCodeRepository.java
@@ -1,0 +1,39 @@
+package com.sparta.couponpop.domain.coupon.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@Repository
+@RequiredArgsConstructor
+public class TemporaryCouponCodeRepository {
+
+    private static final String TEMP_COUPON_PREFIX = "TEMP_COUPON:";
+    private static final String DELIMITER = ":";
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    // 임시 쿠폰 코드 저장 (TTL 적용)
+    public void setTemporaryCoupon(Long couponId, String tempCode, long ttlSeconds) {
+        String key = generateTempCouponKey(couponId, tempCode);
+        redisTemplate.opsForValue().set(key, couponId, Duration.ofSeconds(ttlSeconds));
+    }
+
+    // 임시 코드 검증
+    public boolean validateTemporaryCoupon(Long couponId, String tempCode) {
+        String key = generateTempCouponKey(couponId, tempCode);
+        return redisTemplate.hasKey(key);
+    }
+
+    // 사용 후 삭제
+    public void deleteTemporaryCoupon(Long couponId, String tempCode) {
+        String key = generateTempCouponKey(couponId, tempCode);
+        redisTemplate.delete(key);
+    }
+
+    private static String generateTempCouponKey(Long couponId, String tempCode) {
+        return TEMP_COUPON_PREFIX + couponId + DELIMITER + tempCode;
+    }
+}

--- a/src/main/java/com/sparta/couponpop/domain/coupon/repository/TemporaryCouponCodeRepository.java
+++ b/src/main/java/com/sparta/couponpop/domain/coupon/repository/TemporaryCouponCodeRepository.java
@@ -16,9 +16,9 @@ public class TemporaryCouponCodeRepository {
     private final RedisTemplate<String, Object> redisTemplate;
 
     // 임시 쿠폰 코드 저장 (TTL 적용)
-    public void setTemporaryCoupon(Long couponId, String tempCode, long ttlSeconds) {
+    public void setTemporaryCoupon(Long couponId, String tempCode, String couponCode, long ttlSeconds) {
         String key = generateTempCouponKey(couponId, tempCode);
-        redisTemplate.opsForValue().set(key, couponId, Duration.ofSeconds(ttlSeconds));
+        redisTemplate.opsForValue().set(key, couponCode, Duration.ofSeconds(ttlSeconds));
     }
 
     // 임시 코드 검증

--- a/src/main/java/com/sparta/couponpop/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/sparta/couponpop/domain/coupon/service/CouponService.java
@@ -30,6 +30,8 @@ import java.util.UUID;
 @Transactional(readOnly = true)
 public class CouponService {
 
+    private static final long TEMP_CODE_TTL_SECONDS = 600L;
+
     private final MemberRepository memberRepository;
     private final StoreRepository storeRepository;
     private final CouponEventRepository couponEventRepository;
@@ -87,7 +89,7 @@ public class CouponService {
         Optional<String> tempCode = Optional.empty();
         if (coupon.isAvailable()) {
             String code = UUID.randomUUID().toString();
-            temporaryCouponCodeRepository.setTemporaryCoupon(couponId, code, 600);
+            temporaryCouponCodeRepository.setTemporaryCoupon(couponId, code, TEMP_CODE_TTL_SECONDS);
             tempCode = Optional.of(code);
             log.info("임시 쿠폰 Redis 저장");
         }

--- a/src/main/java/com/sparta/couponpop/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/sparta/couponpop/domain/coupon/service/CouponService.java
@@ -89,7 +89,7 @@ public class CouponService {
         Optional<String> tempCode = Optional.empty();
         if (coupon.isAvailable()) {
             String code = UUID.randomUUID().toString();
-            temporaryCouponCodeRepository.setTemporaryCoupon(couponId, code, TEMP_CODE_TTL_SECONDS);
+            temporaryCouponCodeRepository.setTemporaryCoupon(couponId, code, coupon.getCouponCode(), TEMP_CODE_TTL_SECONDS);
             tempCode = Optional.of(code);
             log.info("임시 쿠폰 Redis 저장");
         }

--- a/src/main/java/com/sparta/couponpop/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/sparta/couponpop/domain/coupon/service/CouponService.java
@@ -1,9 +1,11 @@
 package com.sparta.couponpop.domain.coupon.service;
 
 import com.sparta.couponpop.common.exception.GlobalException;
+import com.sparta.couponpop.domain.coupon.dto.response.CouponDetailResponse;
 import com.sparta.couponpop.domain.coupon.entity.Coupon;
 import com.sparta.couponpop.domain.coupon.exception.CouponErrorCode;
 import com.sparta.couponpop.domain.coupon.repository.CouponRepository;
+import com.sparta.couponpop.domain.coupon.repository.TemporaryCouponCodeRepository;
 import com.sparta.couponpop.domain.couponevent.entity.CouponEvent;
 import com.sparta.couponpop.domain.couponevent.exception.CouponEventErrorCode;
 import com.sparta.couponpop.domain.couponevent.repository.CouponEventRepository;
@@ -14,11 +16,15 @@ import com.sparta.couponpop.domain.store.entity.Store;
 import com.sparta.couponpop.domain.store.exception.StoreErrorCode;
 import com.sparta.couponpop.domain.store.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -28,6 +34,7 @@ public class CouponService {
     private final StoreRepository storeRepository;
     private final CouponEventRepository couponEventRepository;
     private final CouponRepository couponRepository;
+    private final TemporaryCouponCodeRepository temporaryCouponCodeRepository;
 
     @Transactional
     public void issueEventCoupon(Long memberId, Long storeId, Long eventId, LocalDateTime issuedTime) {
@@ -47,11 +54,44 @@ public class CouponService {
         // 발급 처리
         event.issue();
 
+        // TODO : 쿠폰 생성 시 만료 시간 누락
         // 쿠폰 생성 및 저장
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new GlobalException(MemberErrorCode.MEMBER_NOT_FOUND));
         Coupon issuedCoupon = Coupon.createIssuedCoupon(member, event, issuedTime);
         couponRepository.save(issuedCoupon);
+    }
+
+    /**
+     * 쿠폰 상세 조회 및 임시 사용 코드 발급
+     *
+     * <p>쿠폰 ID와 회원 ID를 기반으로 쿠폰을 조회하고, 해당 회원이 소유한 쿠폰인지 검증합니다.
+     * 사용 가능한 쿠폰인 경우, 임시 코드(UUID)를 발급하고 Redis에 10분 TTL로 저장합니다.
+     *
+     * <p>임시 코드는 Optional로 반환되며, 사용 불가 쿠폰의 경우 포함되지 않습니다.
+     *
+     * @param couponId 조회할 쿠폰 ID
+     * @param memberId 요청한 회원 ID
+     * @return 쿠폰 상세 정보와 임시 코드(Optional)가 포함된 응답
+     * @throws GlobalException 쿠폰이 존재하지 않거나 접근 권한이 없는 경우 발생
+     */
+    public CouponDetailResponse getCouponDetail(Long couponId, Long memberId) {
+        Coupon coupon = couponRepository.findByIdWithCouponEventAndStore(couponId)
+                .orElseThrow(() -> new GlobalException(CouponErrorCode.COUPON_NOT_FOUND));
+
+        if (!coupon.getMember().getId().equals(memberId)) {
+            throw new GlobalException(CouponErrorCode.COUPON_ACCESS_DENIED);
+        }
+
+        // 임시 코드 발급 + Redis 저장 (TTL 10분)
+        Optional<String> tempCode = Optional.empty();
+        if (coupon.isAvailable()) {
+            String code = UUID.randomUUID().toString();
+            temporaryCouponCodeRepository.setTemporaryCoupon(couponId, code, 600);
+            tempCode = Optional.of(code);
+            log.info("임시 쿠폰 Redis 저장");
+        }
+        return CouponDetailResponse.from(coupon, tempCode);
     }
 
     private CouponEvent validateEventBelongsToStore(Long eventId, Store store) {

--- a/src/main/resources/db/migration/V11__add_expire_at_column_to_coupons_table.sql
+++ b/src/main/resources/db/migration/V11__add_expire_at_column_to_coupons_table.sql
@@ -1,0 +1,3 @@
+alter table coupons
+    ADD COLUMN expire_at DATETIME NOT NULL COMMENT '쿠폰 만료 시간'
+;

--- a/src/test/java/com/sparta/couponpop/domain/coupon/controller/CouponControllerTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/coupon/controller/CouponControllerTest.java
@@ -6,6 +6,8 @@ import com.sparta.couponpop.common.security.JwtAuthenticationToken;
 import com.sparta.couponpop.common.security.JwtProvider;
 import com.sparta.couponpop.common.security.dto.AuthMember;
 import com.sparta.couponpop.domain.coupon.dto.request.CouponIssueRequest;
+import com.sparta.couponpop.domain.coupon.dto.response.CouponDetailResponse;
+import com.sparta.couponpop.domain.coupon.enums.CouponStatus;
 import com.sparta.couponpop.domain.coupon.exception.CouponErrorCode;
 import com.sparta.couponpop.domain.coupon.service.CouponService;
 import com.sparta.couponpop.domain.couponevent.exception.CouponEventErrorCode;
@@ -28,9 +30,11 @@ import java.time.LocalDateTime;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -206,4 +210,102 @@ class CouponControllerTest {
         }
     }
 
+    @Nested
+    @DisplayName("쿠폰 정보 상세 조회 요청")
+    class GetCouponDetailTests {
+
+        public static CouponDetailResponse createSample(Long storeId, Long eventId, Long couponId) {
+            // QR 코드
+            CouponDetailResponse.QrCode qrCode = new CouponDetailResponse.QrCode(
+                    "https://couponpop.com/q/ABC123XYZ",
+                    "사장님께 QR코드를 보여주세요"
+            );
+
+            // 이벤트 기간
+            CouponDetailResponse.EventInfo.EventPeriod period = new CouponDetailResponse.EventInfo.EventPeriod(
+                    LocalDateTime.of(2025, 10, 21, 0, 0),
+                    LocalDateTime.of(2025, 10, 31, 23, 59)
+            );
+
+            //  이벤트 정보
+            CouponDetailResponse.EventInfo eventInfo = new CouponDetailResponse.EventInfo(
+                    eventId,
+                    "아메리카노 1+1 이벤트",
+                    period
+            );
+
+            // 매장 정보
+            CouponDetailResponse.StoreInfo storeInfo = new CouponDetailResponse.StoreInfo(
+                    storeId,
+                    "스타벅스 강남점",
+                    "서울 강남구 역삼동 123-45",
+                    "02-1234-5678"
+            );
+
+            // CouponDetailResponse 생성
+            return new CouponDetailResponse(
+                    couponId,
+                    CouponStatus.AVAILABLE,
+                    LocalDateTime.of(2025, 10, 21, 12, 0),
+                    LocalDateTime.of(2025, 11, 21, 23, 59),
+                    null,
+                    qrCode,
+                    eventInfo,
+                    storeInfo
+            );
+        }
+
+        @Test
+        @DisplayName("쿠폰 정보 상세 조회 요청 - 200 반환")
+        void getCouponDetail_Success() throws Exception {
+            // given
+            Long couponId = 1L;
+            CouponDetailResponse response = createSample(100L, 1L, couponId);
+
+            given(couponService.getCouponDetail(anyLong(), anyLong())).willReturn(response);
+
+            // when & then
+            mockMvc.perform(
+                            get("/api/v1/coupons/{couponId}", couponId)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.id").value(1L))
+                    .andExpect(jsonPath("$.data.status").value("AVAILABLE"))
+                    .andExpect(jsonPath("$.data.event.id").value(1L))
+                    .andExpect(jsonPath("$.data.store.id").value(100L));
+        }
+
+        @Test
+        @DisplayName("쿠폰 정보 상세 조회 실패 - 쿠폰 없음")
+        void getCouponDetail_NotFound() throws Exception {
+            // given
+            willThrow(new GlobalException(CouponErrorCode.COUPON_NOT_FOUND))
+                    .given(couponService)
+                    .getCouponDetail(anyLong(), anyLong());
+
+            // when & then
+            mockMvc.perform(
+                            get("/api/v1/coupons/{couponId}", 999L)
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error.message").value(CouponErrorCode.COUPON_NOT_FOUND.getMessage()));
+        }
+
+        @Test
+        @DisplayName("쿠폰 정보 상세 조회 실패 - 쿠폰 접근 권한 없음")
+        void getCouponDetail_AccessDenied() throws Exception {
+            // given
+            willThrow(new GlobalException(CouponErrorCode.COUPON_ACCESS_DENIED))
+                    .given(couponService)
+                    .getCouponDetail(anyLong(), anyLong());
+
+            // when & then
+            mockMvc.perform(
+                            get("/api/v1/coupons/{couponId}", 999L)
+                    )
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.error.message").value(CouponErrorCode.COUPON_ACCESS_DENIED.getMessage()));
+        }
+    }
 }

--- a/src/test/java/com/sparta/couponpop/domain/coupon/service/CouponServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/coupon/service/CouponServiceTest.java
@@ -90,6 +90,7 @@ class CouponServiceTest {
 
         coupon = TestUtils.createEntity(Coupon.class, Map.of(
                 "id", 1L,
+                "couponCode", "CPN-9515BD7FE9CD",
                 "receivedAt", couponIssuedAt,
                 "expireAt", eventEndAt,
                 "couponStatus", CouponStatus.AVAILABLE,

--- a/src/test/java/com/sparta/couponpop/domain/coupon/service/CouponServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/coupon/service/CouponServiceTest.java
@@ -239,7 +239,7 @@ class CouponServiceTest {
             assertThat(response.qrCode()).isNotNull();
 
             verify(temporaryCouponCodeRepository, times(1))
-                    .setTemporaryCoupon(anyLong(), anyString(), anyLong());
+                    .setTemporaryCoupon(anyLong(), anyString(), anyString(), anyLong());
         }
 
         @Test
@@ -269,7 +269,7 @@ class CouponServiceTest {
             assertThat(response.qrCode()).isNull();
 
             verify(temporaryCouponCodeRepository, times(0))
-                    .setTemporaryCoupon(anyLong(), anyString(), anyLong());
+                    .setTemporaryCoupon(anyLong(), anyString(), anyString(), anyLong());
         }
 
         @Test

--- a/src/test/java/com/sparta/couponpop/domain/coupon/service/CouponServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/coupon/service/CouponServiceTest.java
@@ -1,9 +1,12 @@
 package com.sparta.couponpop.domain.coupon.service;
 
 import com.sparta.couponpop.common.exception.GlobalException;
+import com.sparta.couponpop.domain.coupon.dto.response.CouponDetailResponse;
 import com.sparta.couponpop.domain.coupon.entity.Coupon;
+import com.sparta.couponpop.domain.coupon.enums.CouponStatus;
 import com.sparta.couponpop.domain.coupon.exception.CouponErrorCode;
 import com.sparta.couponpop.domain.coupon.repository.CouponRepository;
+import com.sparta.couponpop.domain.coupon.repository.TemporaryCouponCodeRepository;
 import com.sparta.couponpop.domain.couponevent.entity.CouponEvent;
 import com.sparta.couponpop.domain.couponevent.enums.CouponEventStatus;
 import com.sparta.couponpop.domain.couponevent.exception.CouponEventErrorCode;
@@ -29,10 +32,11 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class CouponServiceTest {
@@ -49,13 +53,22 @@ class CouponServiceTest {
     @Mock
     private CouponRepository couponRepository;
 
+    @Mock
+    private TemporaryCouponCodeRepository temporaryCouponCodeRepository;
+
     @InjectMocks
     private CouponService couponService;
 
     private Member member;
     private Store store;
     private CouponEvent couponEvent;
+    private Coupon coupon;
+
     private static final LocalDateTime issuedTime = LocalDateTime.of(2025, 10, 20, 16, 20);
+    private static final LocalDateTime eventStartAt = issuedTime.minusHours(1);
+    private static final LocalDateTime eventEndAt = issuedTime.plusDays(1);
+
+    private static final LocalDateTime couponIssuedAt = eventStartAt.plusHours(4);
 
     @BeforeEach
     void setUp() {
@@ -68,11 +81,20 @@ class CouponServiceTest {
         couponEvent = TestUtils.createEntity(CouponEvent.class, Map.of(
                 "id", 1L,
                 "name", "이벤트 제목",
-                "eventStartAt", issuedTime.minusHours(1),
-                "eventEndAt", issuedTime.plusDays(1),
+                "eventStartAt", eventStartAt,
+                "eventEndAt", eventEndAt,
                 "totalCount", 10,
                 "couponEventStatus", CouponEventStatus.IN_PROGRESS,
                 "store", store
+        ));
+
+        coupon = TestUtils.createEntity(Coupon.class, Map.of(
+                "id", 1L,
+                "receivedAt", couponIssuedAt,
+                "expireAt", eventEndAt,
+                "couponStatus", CouponStatus.AVAILABLE,
+                "couponEvent", couponEvent,
+                "member", member
         ));
     }
 
@@ -191,6 +213,87 @@ class CouponServiceTest {
             assertThatThrownBy(() -> couponService.issueEventCoupon(member.getId(), store.getId(), couponEvent.getId(), issuedTime))
                     .isInstanceOf(GlobalException.class)
                     .hasMessage(CouponErrorCode.COUPON_ALREADY_ISSUED.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("쿠폰 정보 상세 조회 (getCouponDetail)")
+    class GetCouponDetailTests {
+
+        @Test
+        @DisplayName("사용 가능한(Available) 쿠폰")
+        void getCouponDetail_AvailableCoupon() {
+            // given
+            given(couponRepository.findByIdWithCouponEventAndStore(anyLong())).willReturn(Optional.of(coupon));
+
+            // when
+            CouponDetailResponse response = couponService.getCouponDetail(coupon.getId(), member.getId());
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.status()).isEqualTo(CouponStatus.AVAILABLE);
+            assertThat(response)
+                    .extracting("id", "issuedAt", "expireAt")
+                    .containsExactly(1L, couponIssuedAt, eventEndAt);
+            assertThat(response.usedAt()).isNull();
+            assertThat(response.qrCode()).isNotNull();
+
+            verify(temporaryCouponCodeRepository, times(1))
+                    .setTemporaryCoupon(anyLong(), anyString(), anyLong());
+        }
+
+        @Test
+        @DisplayName("사용된(Used) 쿠폰")
+        void getCouponDetail_UnavailableCoupon() {
+            // given
+            LocalDateTime usedAt = couponIssuedAt.plusHours(5);
+            coupon = TestUtils.createEntity(Coupon.class, Map.of(
+                    "id", 1L,
+                    "receivedAt", couponIssuedAt,
+                    "expireAt", eventEndAt,
+                    "usedAt", usedAt,
+                    "couponStatus", CouponStatus.USED,
+                    "couponEvent", couponEvent,
+                    "member", member
+            ));
+
+            given(couponRepository.findByIdWithCouponEventAndStore(anyLong())).willReturn(Optional.of(coupon));
+
+            // when
+            CouponDetailResponse response = couponService.getCouponDetail(coupon.getId(), member.getId());
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.status()).isEqualTo(CouponStatus.USED);
+            assertThat(response.usedAt()).isNotNull();
+            assertThat(response.qrCode()).isNull();
+
+            verify(temporaryCouponCodeRepository, times(0))
+                    .setTemporaryCoupon(anyLong(), anyString(), anyLong());
+        }
+
+        @Test
+        @DisplayName("쿠폰 상세 조회 실패 - 쿠폰 없음")
+        void getCouponDetail_NotFound() {
+            // given
+            given(couponRepository.findByIdWithCouponEventAndStore(anyLong())).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> couponService.getCouponDetail(coupon.getId(), member.getId()))
+                    .isInstanceOf(GlobalException.class)
+                    .hasMessage(CouponErrorCode.COUPON_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("쿠폰 상세 조회 실패 - 접근 권한 없음")
+        void getCouponDetail_AccessDenied() {
+            // given
+            given(couponRepository.findByIdWithCouponEventAndStore(anyLong())).willReturn(Optional.of(coupon));
+
+            // when & then
+            assertThatThrownBy(() -> couponService.getCouponDetail(coupon.getId(), 999L))
+                    .isInstanceOf(GlobalException.class)
+                    .hasMessage(CouponErrorCode.COUPON_ACCESS_DENIED.getMessage());
         }
     }
 }


### PR DESCRIPTION
## 🔗 **연관된 이슈**
- close #37 

<br>

## 📝 **작업 내용**

1. **쿠폰 상세 조회 API**
   - 사용자가 쿠폰 상세 정보를 요청
   - 쿠폰 소유권 검증 후 응답 준비

2. **임시 코드 생성**
   - UUID 등으로 1회용 임시 코드 생성
   - Frontend에서 QR 링크 또는 코드로 사용

3. **Redis 저장**
   - Key: `TEMP_COUPON:{couponId}:{tempCode}`
   - Value: 실제 쿠폰 ID 또는 상태(JSON)
   - TTL 적용 (예: 5~10분) → 자동 만료

4. **QR 또는 임시 코드 전달**
   - 프론트엔드에 QR 링크 또는 임시 코드 포함
   - 사용자에게 코드/QR 표시

5. **QR 스캔/사용**
   - 사용자가 QR 스캔 또는 코드 입력
   - Redis 조회 후 유효성 확인
   - 실제 쿠폰 상태(DB) 변경 (사용 처리)
   - Redis 임시 코드 삭제 → 1회성 보장

<br>

## 🧪 테스트 범위

### 1️⃣ 정상 케이스
| 테스트 | 설명 | 기대 결과 |
|--------|------|-----------|
| Controller | 쿠폰 상세 조회 요청 성공 | `200 OK` 반환, JSON 응답에 `id`, `status`, `event.id`, `store.id` 포함 |
| Service | 사용 가능한 쿠폰 조회 | `CouponDetailResponse` 정상 반환, `QR 코드` 생성 확인 |
| Service | 사용된 쿠폰 조회 | `CouponDetailResponse` 정상 반환, `QR 코드` 미생성 확인 |

### 2️⃣ 예외 케이스
| 상황 | Controller 결과 | Service 예외 |
|------|----------------|---------------|
| 쿠폰 없음 | `400 Bad Request` + `COUPON_NOT_FOUND` | `COUPON_NOT_FOUND` |
| 접근 권한 없음 | `403 Forbidden` + `COUPON_ACCESS_DENIED` | `COUPON_ACCESS_DENIED` |

### 3️⃣ 핵심 검증 포인트
- status별 로직 분기 (AVAILABLE / USED)  
- QR 코드 생성 여부  
- HTTP 상태 코드 및 JSON 구조 확인  
- 서비스와 컨트롤러 계층 간 일관성  
- 예외 처리 메시지 검증

---

### 4️⃣ 비고
- 컨트롤러 테스트는 **핵심 필드(id, status, event.id, store.id)** 중심 검증  
- 상세 필드(`issuedAt`, `expireAt`)는 서비스 단위 테스트에서 검증  
- DTO 구조 변경 시 컨트롤러 테스트는 최소한 핵심 필드만 유지

