### PR TITLE
feat: 쿠폰 사용 API

### DIFF
--- a/src/main/java/com/sparta/couponpop/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/sparta/couponpop/domain/coupon/controller/CouponController.java
@@ -4,6 +4,7 @@ import com.sparta.couponpop.common.response.ApiResponse;
 import com.sparta.couponpop.common.security.annotation.CurrentMember;
 import com.sparta.couponpop.common.security.dto.AuthMember;
 import com.sparta.couponpop.domain.coupon.dto.request.CouponIssueRequest;
+import com.sparta.couponpop.domain.coupon.dto.request.UseCouponRequest;
 import com.sparta.couponpop.domain.coupon.dto.response.CouponDetailResponse;
 import com.sparta.couponpop.domain.coupon.service.CouponService;
 import jakarta.validation.Valid;
@@ -31,5 +32,12 @@ public class CouponController {
     public ResponseEntity<ApiResponse<CouponDetailResponse>> getCouponDetail(@PathVariable Long couponId, @CurrentMember AuthMember authMember) {
         CouponDetailResponse response = couponService.getCouponDetail(couponId, authMember.id());
         return ApiResponse.success(response);
+    }
+
+    @PostMapping("/coupons/use")
+    public ResponseEntity<ApiResponse<Void>> useCoupon(@Valid @RequestBody UseCouponRequest request, @CurrentMember AuthMember authMember) {
+        LocalDateTime usedAt = LocalDateTime.now();
+        couponService.useCoupon(request.couponId(), request.qrCode(), authMember.id(), usedAt);
+        return ApiResponse.noContent();
     }
 }

--- a/src/main/java/com/sparta/couponpop/domain/coupon/dto/request/UseCouponRequest.java
+++ b/src/main/java/com/sparta/couponpop/domain/coupon/dto/request/UseCouponRequest.java
@@ -1,0 +1,14 @@
+package com.sparta.couponpop.domain.coupon.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record UseCouponRequest(
+
+        @NotBlank(message = "QR 코드는 필수입니다.")
+        String qrCode,
+
+        @NotNull(message = "사용하려는 쿠폰 ID는 필수입니다.")
+        Long couponId
+) {
+}

--- a/src/main/java/com/sparta/couponpop/domain/coupon/entity/Coupon.java
+++ b/src/main/java/com/sparta/couponpop/domain/coupon/entity/Coupon.java
@@ -95,7 +95,7 @@ public class Coupon extends BaseEntity {
         }
         // 쿠폰 사용 가능 상태 검증 - AVAILABLE 이 아닌 USED, EXPIRED, CANCELED 이면 사용 못하는 쿠폰
         if (!isAvailable()) {
-            throw new GlobalException(CouponErrorCode.COUPON_ALREADY_USED);
+            throw new GlobalException(CouponErrorCode.COUPON_NOT_AVAILABLE);
         }
         // 만료 시간 검증
         if (isExpired(usedAt)) {

--- a/src/main/java/com/sparta/couponpop/domain/coupon/entity/Coupon.java
+++ b/src/main/java/com/sparta/couponpop/domain/coupon/entity/Coupon.java
@@ -84,9 +84,13 @@ public class Coupon extends BaseEntity {
         return now.isAfter(this.expireAt);
     }
 
+    public boolean isUsed() {
+        return this.usedAt != null && CouponStatus.USED.equals(this.couponStatus);
+    }
+
     public void use(LocalDateTime usedAt) {
         // 이미 사용된 쿠폰 방어 로직
-        if (this.usedAt != null) {
+        if (isUsed()) {
             throw new GlobalException(CouponErrorCode.COUPON_ALREADY_USED);
         }
         // 쿠폰 사용 가능 상태 검증 - AVAILABLE 이 아닌 USED, EXPIRED, CANCELED 이면 사용 못하는 쿠폰
@@ -102,7 +106,5 @@ public class Coupon extends BaseEntity {
         this.usedAt = usedAt;
     }
 
-    public boolean isUsed() {
-        return CouponStatus.USED.equals(this.couponStatus);
-    }
+
 }

--- a/src/main/java/com/sparta/couponpop/domain/coupon/entity/Coupon.java
+++ b/src/main/java/com/sparta/couponpop/domain/coupon/entity/Coupon.java
@@ -1,7 +1,9 @@
 package com.sparta.couponpop.domain.coupon.entity;
 
 import com.sparta.couponpop.common.entity.BaseEntity;
+import com.sparta.couponpop.common.exception.GlobalException;
 import com.sparta.couponpop.domain.coupon.enums.CouponStatus;
+import com.sparta.couponpop.domain.coupon.exception.CouponErrorCode;
 import com.sparta.couponpop.domain.couponevent.entity.CouponEvent;
 import com.sparta.couponpop.domain.member.entity.Member;
 import jakarta.persistence.*;
@@ -75,6 +77,29 @@ public class Coupon extends BaseEntity {
 
     public boolean isAvailable() {
         return CouponStatus.AVAILABLE.equals(this.couponStatus);
+    }
+
+    // 쿠폰이 만료되었는지
+    public boolean isExpired(LocalDateTime now) {
+        return now.isAfter(this.expireAt);
+    }
+
+    public void use(LocalDateTime usedAt) {
+        // 이미 사용된 쿠폰 방어 로직
+        if (this.usedAt != null) {
+            throw new GlobalException(CouponErrorCode.COUPON_ALREADY_USED);
+        }
+        // 쿠폰 사용 가능 상태 검증 - AVAILABLE 이 아닌 USED, EXPIRED, CANCELED 이면 사용 못하는 쿠폰
+        if (!isAvailable()) {
+            throw new GlobalException(CouponErrorCode.COUPON_ALREADY_USED);
+        }
+        // 만료 시간 검증
+        if (isExpired(usedAt)) {
+            throw new GlobalException(CouponErrorCode.COUPON_EXPIRED);
+        }
+
+        this.couponStatus = CouponStatus.USED;
+        this.usedAt = usedAt;
     }
 
     public boolean isUsed() {

--- a/src/main/java/com/sparta/couponpop/domain/coupon/exception/CouponErrorCode.java
+++ b/src/main/java/com/sparta/couponpop/domain/coupon/exception/CouponErrorCode.java
@@ -15,7 +15,8 @@ public enum CouponErrorCode implements ErrorCode {
     COUPON_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않은 쿠폰입니다."),
     COUPON_INVALID_TEMP_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 QR 코드입니다."),
     COUPON_EXPIRED(HttpStatus.BAD_REQUEST, "만료된 쿠폰은 사용할 수 없습니다."),
-    COUPON_ALREADY_USED(HttpStatus.BAD_REQUEST, "이미 사용된 쿠폰입니다.");
+    COUPON_ALREADY_USED(HttpStatus.BAD_REQUEST, "이미 사용된 쿠폰입니다."),
+    COUPON_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "쿠폰이 사용 가능한 상태가 아닙니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/sparta/couponpop/domain/coupon/exception/CouponErrorCode.java
+++ b/src/main/java/com/sparta/couponpop/domain/coupon/exception/CouponErrorCode.java
@@ -12,9 +12,13 @@ public enum CouponErrorCode implements ErrorCode {
     COUPON_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 쿠폰에 접근할 수 없습니다."),
 
     COUPON_ALREADY_ISSUED(HttpStatus.BAD_REQUEST, "해당 쿠폰은 이미 발급되었습니다."),
-    COUPON_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않은 쿠폰입니다.");
+    COUPON_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않은 쿠폰입니다."),
+    COUPON_INVALID_TEMP_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 QR 코드입니다."),
+    COUPON_EXPIRED(HttpStatus.BAD_REQUEST, "만료된 쿠폰은 사용할 수 없습니다."),
+    COUPON_ALREADY_USED(HttpStatus.BAD_REQUEST, "이미 사용된 쿠폰입니다.");
 
 
     private final HttpStatus httpStatus;
     private final String message;
+
 }

--- a/src/main/java/com/sparta/couponpop/domain/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/sparta/couponpop/domain/coupon/repository/CouponRepository.java
@@ -2,7 +2,9 @@ package com.sparta.couponpop.domain.coupon.repository;
 
 import com.sparta.couponpop.domain.coupon.entity.Coupon;
 import com.sparta.couponpop.domain.coupon.enums.CouponStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -27,4 +29,13 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
             where c.id = :couponId
             """)
     Optional<Coupon> findByIdWithCouponEventAndStore(@Param("couponId") Long couponId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            select c
+            from Coupon c
+                join fetch c.couponEvent ce
+            where c.id = :couponId
+            """)
+    Optional<Coupon> findByIdWithCouponEventForUpdate(@Param("couponId") Long couponId);
 }

--- a/src/main/java/com/sparta/couponpop/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/sparta/couponpop/domain/coupon/service/CouponService.java
@@ -85,6 +85,7 @@ public class CouponService {
             throw new GlobalException(CouponErrorCode.COUPON_ACCESS_DENIED);
         }
 
+        // TODO : 쿠폰 만료 여부 표시를 날짜로 할지 일관 처리 할지
         // 임시 코드 발급 + Redis 저장 (TTL 10분)
         Optional<String> tempCode = Optional.empty();
         if (coupon.isAvailable()) {
@@ -94,6 +95,69 @@ public class CouponService {
             log.info("임시 쿠폰 Redis 저장");
         }
         return CouponDetailResponse.from(coupon, tempCode);
+    }
+
+    /**
+     * 쿠폰 사용 처리 메서드.
+     *
+     * <p>사용자가 QR 코드(임시 코드)를 통해 쿠폰을 사용할 때 호출되며,
+     * 다음 과정을 순차적으로 수행한다.</p>
+     *
+     * <ol>
+     *     <li>Redis에 저장된 임시 코드(QR) 유효성 검증</li>
+     *     <li>비관적 락 기반 쿠폰 + 이벤트 조회 (중복 사용 방어)</li>
+     *     <li>이벤트 진행 상태 검증 (시작/종료 시간 포함)</li>
+     *     <li>쿠폰 소유자 검증</li>
+     *     <li>쿠폰 사용 가능 상태 검증 (USED, EXPIRED 등 방지)</li>
+     *     <li>쿠폰 사용 처리 및 사용 시각 기록</li>
+     *     <li>Redis에 저장된 임시 코드 삭제</li>
+     * </ol>
+     *
+     * <p><b>동시성 처리:</b> 현재는 비관적 락을 사용 중이며,
+     * 추후 Redis 분산 락(Redisson) 또는 낙관적 락(@Version)을 통한 개선 예정.</p>
+     *
+     * @param couponId 쿠폰 ID
+     * @param qrCode   쿠폰 사용 시 전달된 QR 코드(임시 코드)
+     * @param memberId 쿠폰 사용 요청자의 회원 ID
+     * @param usedAt   쿠폰 사용 시각
+     * @throws GlobalException 유효하지 않은 코드, 이벤트 기간 종료, 소유자 불일치, 이미 사용된 쿠폰 등 예외 발생
+     */
+    @Transactional
+    public void useCoupon(Long couponId, String qrCode, Long memberId, LocalDateTime usedAt) {
+
+        /**
+         * TODO: Redis에서 임시 코드 원자적 검증 + 조회
+         * - 현재는 validateTemporaryCoupon 후 delete 순서
+         * - getAndDelete 또는 Lua 스크립트로 동시성 안전하게 처리
+         */
+        //  Redis 임시 코드 검증
+        if (!temporaryCouponCodeRepository.validateTemporaryCoupon(couponId, qrCode)) {
+            throw new GlobalException(CouponErrorCode.COUPON_INVALID_TEMP_CODE);
+        }
+
+        /**
+         * TODO: [동시성 개선]
+         * 현재는 비관적 락(Pessimistic Lock)으로 중복 사용을 방어하고 있음.
+         * 추후 Redis 기반 분산 락 또는 낙관적 락(Optimistic Lock)으로 개선 예정.
+         * ex) Redisson, @Version 등 활용 가능
+         */
+        // 쿠폰 + 이벤트 조회
+        Coupon coupon = couponRepository.findByIdWithCouponEventForUpdate(couponId)
+                .orElseThrow(() -> new GlobalException(CouponErrorCode.COUPON_NOT_FOUND));
+
+        // 이벤트 상태 검증
+        coupon.getCouponEvent().validateInProgress(usedAt);
+
+        // 쿠폰 소유자 검증
+        if (!coupon.getMember().getId().equals(memberId)) {
+            throw new GlobalException(CouponErrorCode.COUPON_ACCESS_DENIED);
+        }
+
+        // 쿠폰 사용
+        coupon.use(usedAt);
+
+        // Redis 임시 코드 삭제
+        temporaryCouponCodeRepository.deleteTemporaryCoupon(couponId, qrCode);
     }
 
     private CouponEvent validateEventBelongsToStore(Long eventId, Store store) {

--- a/src/main/java/com/sparta/couponpop/domain/couponevent/entity/CouponEvent.java
+++ b/src/main/java/com/sparta/couponpop/domain/couponevent/entity/CouponEvent.java
@@ -111,4 +111,16 @@ public class CouponEvent extends BaseEntity {
     public void issue() {
         this.issuedCount += 1;
     }
+
+    public void validateInProgress(LocalDateTime now) {
+        if (now.isBefore(eventStartAt)) {
+            throw new GlobalException(CouponEventErrorCode.EVENT_NOT_STARTED);
+        }
+        if (now.isAfter(eventEndAt)) {
+            throw new GlobalException(CouponEventErrorCode.EVENT_ENDED);
+        }
+        if (couponEventStatus != CouponEventStatus.IN_PROGRESS) {
+            throw new GlobalException(CouponEventErrorCode.EVENT_NOT_IN_PROGRESS);
+        }
+    }
 }

--- a/src/main/java/com/sparta/couponpop/domain/couponevent/exception/CouponEventErrorCode.java
+++ b/src/main/java/com/sparta/couponpop/domain/couponevent/exception/CouponEventErrorCode.java
@@ -16,6 +16,8 @@ public enum CouponEventErrorCode implements ErrorCode {
     EVENT_NOT_BELONG_TO_STORE(HttpStatus.BAD_REQUEST, "해당 매장에서 진행되지 않는 이벤트입니다."),
     EVENT_NOT_IN_PROGRESS_TIME(HttpStatus.BAD_REQUEST, "이벤트 진행 시간이 아닙니다."),
     EVENT_COUPON_SOLD_OUT(HttpStatus.BAD_REQUEST, "이벤트 쿠폰이 모두 소진되었습니다."),
+    EVENT_NOT_STARTED(HttpStatus.BAD_REQUEST, "이벤트가 아직 시작되지 않았습니다."),
+    EVENT_ENDED(HttpStatus.BAD_REQUEST, "이벤트가 종료되었습니다."),
     EVENT_NOT_IN_PROGRESS(HttpStatus.BAD_REQUEST, "현재 진행 중인 이벤트가 아닙니다.");
 
     private final HttpStatus httpStatus;

--- a/src/test/java/com/sparta/couponpop/domain/coupon/controller/CouponControllerTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/coupon/controller/CouponControllerTest.java
@@ -6,6 +6,7 @@ import com.sparta.couponpop.common.security.JwtAuthenticationToken;
 import com.sparta.couponpop.common.security.JwtProvider;
 import com.sparta.couponpop.common.security.dto.AuthMember;
 import com.sparta.couponpop.domain.coupon.dto.request.CouponIssueRequest;
+import com.sparta.couponpop.domain.coupon.dto.request.UseCouponRequest;
 import com.sparta.couponpop.domain.coupon.dto.response.CouponDetailResponse;
 import com.sparta.couponpop.domain.coupon.enums.CouponStatus;
 import com.sparta.couponpop.domain.coupon.exception.CouponErrorCode;
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -28,8 +30,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.times;
@@ -306,6 +307,93 @@ class CouponControllerTest {
                     )
                     .andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.error.message").value(CouponErrorCode.COUPON_ACCESS_DENIED.getMessage()));
+        }
+    }
+
+    @Nested
+    @DisplayName("쿠폰 사용 요청")
+    class UseCouponTests {
+
+        @Test
+        @DisplayName("쿠폰 사용 성공 - 204 No Content")
+        void useCoupon_Success() throws Exception {
+            // given
+            UseCouponRequest request = new UseCouponRequest("TEMP123", 1L);
+
+
+            // when
+            mockMvc.perform(
+                            post("/api/v1/coupons/use")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request))
+                    )
+                    .andDo(print())
+                    .andExpect(status().isNoContent());
+
+            // then
+            verify(couponService, times(1))
+                    .useCoupon(anyLong(), anyString(), anyLong(), any(LocalDateTime.class));
+        }
+
+        @Test
+        @DisplayName("쿠폰 사용 요청 실패 - 임시 코드 유효하지 않음")
+        void useCoupon_InvalidTempCode() throws Exception {
+            // given
+            UseCouponRequest request = new UseCouponRequest("INVALID", 1L);
+
+            Mockito.doThrow(new GlobalException(CouponErrorCode.COUPON_INVALID_TEMP_CODE))
+                    .when(couponService).useCoupon(Mockito.anyLong(), Mockito.anyString(), Mockito.anyLong(), Mockito.any(LocalDateTime.class));
+
+            willThrow(new GlobalException(CouponErrorCode.COUPON_INVALID_TEMP_CODE))
+                    .given(couponService)
+                    .useCoupon(anyLong(), anyString(), anyLong(), any(LocalDateTime.class));
+
+            // when & then
+            mockMvc.perform(
+                            post("/api/v1/coupons/use")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request))
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error.message").value(CouponErrorCode.COUPON_INVALID_TEMP_CODE.getMessage()));
+        }
+
+        @Test
+        @DisplayName("쿠폰 사용 요청 실패 - qrCode 누락")
+        void useCoupon_fail_missingQrCode() throws Exception {
+            String requestBody = """
+                    {
+                        "couponId": 1
+                    }
+                    """;
+
+            mockMvc.perform(
+                            post("/api/v1/coupons/use")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(requestBody)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error.message").value("QR 코드는 필수입니다."));
+        }
+
+        @Test
+        @DisplayName("쿠폰 사용 요청 실패 - couponId 누락")
+        void useCoupon_fail_missingCouponId() throws Exception {
+            String requestBody = """
+                    {
+                        "qrCode": "foejsnvp"
+                    }
+                    """;
+
+            mockMvc.perform(
+                            post("/api/v1/coupons/use")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(requestBody)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error.message").value("사용하려는 쿠폰 ID는 필수입니다."));
         }
     }
 }

--- a/src/test/java/com/sparta/couponpop/domain/coupon/service/CouponServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/coupon/service/CouponServiceTest.java
@@ -432,7 +432,7 @@ class CouponServiceTest {
             // when & then
             assertThatThrownBy(() -> couponService.useCoupon(coupon.getId(), "QR123", member.getId(), usedAt))
                     .isInstanceOf(GlobalException.class)
-                    .hasMessage(CouponErrorCode.COUPON_ALREADY_USED.getMessage());
+                    .hasMessage(CouponErrorCode.COUPON_NOT_AVAILABLE.getMessage());
         }
     }
 }

--- a/src/test/java/com/sparta/couponpop/domain/coupon/service/CouponServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/coupon/service/CouponServiceTest.java
@@ -297,4 +297,142 @@ class CouponServiceTest {
                     .hasMessage(CouponErrorCode.COUPON_ACCESS_DENIED.getMessage());
         }
     }
+
+    @Nested
+    @DisplayName("쿠폰 사용 (useCoupon)")
+    class UseCouponTests {
+
+        @Test
+        @DisplayName("쿠폰 사용 - 성공")
+        void useCoupon_Success() {
+            // given
+            given(temporaryCouponCodeRepository.validateTemporaryCoupon(anyLong(), anyString())).willReturn(true);
+            given(couponRepository.findByIdWithCouponEventForUpdate(anyLong())).willReturn(Optional.of(coupon));
+
+            LocalDateTime usedAt = eventStartAt.plusHours(10);
+            String qrCode = "QR123";
+
+            // when
+            couponService.useCoupon(coupon.getId(), qrCode, member.getId(), usedAt);
+
+            // then
+            assertThat(coupon.getCouponStatus()).isEqualTo(CouponStatus.USED);
+            assertThat(coupon.getUsedAt()).isEqualTo(usedAt);
+
+            verify(temporaryCouponCodeRepository, times(1))
+                    .deleteTemporaryCoupon(anyLong(), anyString());
+        }
+
+        @Test
+        @DisplayName("쿠폰 사용 실패 - 임시 코드 없을 때 예외치")
+        void useCoupon_InvalidQRCode() {
+            // given
+            given(temporaryCouponCodeRepository.validateTemporaryCoupon(anyLong(), anyString())).willReturn(false);
+
+            LocalDateTime usedAt = eventStartAt.plusHours(10);
+            String qrCode = "QR123";
+
+            // when & then
+            assertThatThrownBy(() -> couponService.useCoupon(coupon.getId(), qrCode, member.getId(), usedAt))
+                    .isInstanceOf(GlobalException.class)
+                    .hasMessage(CouponErrorCode.COUPON_INVALID_TEMP_CODE.getMessage());
+        }
+
+        @Test
+        @DisplayName("쿠폰 사용 실패 - 이벤트 시작 전")
+        void useCoupon_EventNotStarted() {
+            // given
+            given(temporaryCouponCodeRepository.validateTemporaryCoupon(anyLong(), anyString())).willReturn(true);
+            given(couponRepository.findByIdWithCouponEventForUpdate(anyLong())).willReturn(Optional.of(coupon));
+
+            LocalDateTime usedAt = eventStartAt.minusMinutes(1);
+            String qrCode = "QR123";
+
+            // when & then
+            assertThatThrownBy(() -> couponService.useCoupon(coupon.getId(), qrCode, member.getId(), usedAt))
+                    .isInstanceOf(GlobalException.class)
+                    .hasMessage(CouponEventErrorCode.EVENT_NOT_STARTED.getMessage());
+        }
+
+        @Test
+        @DisplayName("쿠폰 사용 실패 - 이벤트 종료 후")
+        void useCoupon_EventEnded() {
+            // given
+            given(temporaryCouponCodeRepository.validateTemporaryCoupon(anyLong(), anyString())).willReturn(true);
+            given(couponRepository.findByIdWithCouponEventForUpdate(anyLong())).willReturn(Optional.of(coupon));
+
+            LocalDateTime usedAt = eventEndAt.plusMinutes(1);
+            String qrCode = "QR123";
+
+            // when & then
+            assertThatThrownBy(() -> couponService.useCoupon(coupon.getId(), qrCode, member.getId(), usedAt))
+                    .isInstanceOf(GlobalException.class)
+                    .hasMessage(CouponEventErrorCode.EVENT_ENDED.getMessage());
+        }
+
+        @Test
+        @DisplayName("쿠폰 사용 실패 - 쿠폰 소유자 불일치")
+        void useCoupon_AccessDenied() {
+            // given
+            given(temporaryCouponCodeRepository.validateTemporaryCoupon(anyLong(), anyString())).willReturn(true);
+            given(couponRepository.findByIdWithCouponEventForUpdate(anyLong())).willReturn(Optional.of(coupon));
+
+            LocalDateTime usedAt = eventStartAt.plusHours(10);
+            String qrCode = "QR123";
+
+            // when & then
+            assertThatThrownBy(() -> couponService.useCoupon(coupon.getId(), qrCode, 999L, usedAt))
+                    .isInstanceOf(GlobalException.class)
+                    .hasMessage(CouponErrorCode.COUPON_ACCESS_DENIED.getMessage());
+        }
+
+        @Test
+        @DisplayName("쿠폰 사용 실패 - 쿠폰 이미 사용됨 (usedAt != null)")
+        void useCoupon_AlreadyUsed1() {
+            // given
+            LocalDateTime usedAt = eventStartAt.plusHours(10);
+            coupon = TestUtils.createEntity(Coupon.class, Map.of(
+                    "id", 1L,
+                    "couponCode", "CPN-9515BD7FE9CD",
+                    "receivedAt", couponIssuedAt,
+                    "expireAt", eventEndAt,
+                    "usedAt", usedAt,
+                    "couponStatus", CouponStatus.USED,
+                    "couponEvent", couponEvent,
+                    "member", member
+            ));
+
+            given(temporaryCouponCodeRepository.validateTemporaryCoupon(anyLong(), anyString())).willReturn(true);
+            given(couponRepository.findByIdWithCouponEventForUpdate(anyLong())).willReturn(Optional.of(coupon));
+
+            // when & then
+            assertThatThrownBy(() -> couponService.useCoupon(coupon.getId(), "QR123", member.getId(), usedAt))
+                    .isInstanceOf(GlobalException.class)
+                    .hasMessage(CouponErrorCode.COUPON_ALREADY_USED.getMessage());
+        }
+
+        @Test
+        @DisplayName("쿠폰 사용 실패 - 쿠폰 이미 사용됨 (isAvailable == false)")
+        void useCoupon_AlreadyUsed2() {
+            // given
+            LocalDateTime usedAt = eventStartAt.plusHours(10);
+            coupon = TestUtils.createEntity(Coupon.class, Map.of(
+                    "id", 1L,
+                    "couponCode", "CPN-9515BD7FE9CD",
+                    "receivedAt", couponIssuedAt,
+                    "expireAt", eventEndAt,
+                    "couponStatus", CouponStatus.USED,
+                    "couponEvent", couponEvent,
+                    "member", member
+            ));
+
+            given(temporaryCouponCodeRepository.validateTemporaryCoupon(anyLong(), anyString())).willReturn(true);
+            given(couponRepository.findByIdWithCouponEventForUpdate(anyLong())).willReturn(Optional.of(coupon));
+
+            // when & then
+            assertThatThrownBy(() -> couponService.useCoupon(coupon.getId(), "QR123", member.getId(), usedAt))
+                    .isInstanceOf(GlobalException.class)
+                    .hasMessage(CouponErrorCode.COUPON_ALREADY_USED.getMessage());
+        }
+    }
 }


### PR DESCRIPTION
## 🔗 **연관된 이슈**
- close #39

<br>

## 📝 **작업 내용**


### 1️⃣ 정상 케이스
| 테스트 | 설명 | 기대 결과 |
|--------|------|-----------|
| Controller | 쿠폰 사용 요청 성공 | `204 No Content` 반환, Service `useCoupon` 호출 확인 |
| Service | Redis 임시 코드 존재 + DB 쿠폰 사용 가능 | 쿠폰 상태 `USED`로 변경, `usedAt` 기록, Redis 임시 코드 삭제 확인 |

### 2️⃣ 예외 케이스
| 상황 | Controller 결과 | Service 예외 |
|------|----------------|---------------|
| 임시 코드 없음 | `400 Bad Request` + `COUPON_INVALID_TEMP_CODE` | `COUPON_INVALID_TEMP_CODE` |
| 쿠폰 이미 사용됨 | `400 Bad Request` + `COUPON_ALREADY_USED` | `COUPON_ALREADY_USED` |
| 이벤트 시작 전 | `400 Bad Request` + `EVENT_NOT_STARTED` | `EVENT_NOT_STARTED` |
| 이벤트 종료 후 | `400 Bad Request` + `EVENT_ENDED` | `EVENT_ENDED` |
| 쿠폰 소유자 불일치 | `403 Forbidden` + `COUPON_ACCESS_DENIED` | `COUPON_ACCESS_DENIED` |
| 요청 Body 누락 (couponId/qrCode) | `400 Bad Request` + 필드 메시지 | Bean Validation 예외 |

### 3️⃣ 핵심 검증 포인트
- Redis 임시 코드 존재 여부 확
- DB 쿠폰 상태 검증 및 변경 (`UNUSED → USED`)
- 이벤트 상태 검증 (진행 중 여부)
- 쿠폰 소유자 검증
- HTTP 상태 코드 및 JSON 응답/에러 메시지 확인
- Service와 Controller 계층 간 호출 일관성

### 4️⃣ 비고
- Controller 테스트는 **HTTP 상태 + 핵심 필드 + 요청 Body Validation** 중심
- Service 테스트는 **쿠폰 상태, 이벤트 상태, Redis 삭제**까지 내부 로직 검증
- Redis getAndDelete 원자성, DB 비관적 락 등 동시성 처리 검증은 통합 테스트에서 수행 가능


<br>

