### PR TITLE
feat: 위치 기반 쿠폰 이벤트 알림 및 캐싱 서비스 구현

### DIFF
--- a/.github/workflows/v1-ci-pipeline.yml
+++ b/.github/workflows/v1-ci-pipeline.yml
@@ -59,6 +59,13 @@ jobs:
           REDIS_PORT: 6379
         run: ./gradlew clean build --no-daemon
 
+      - name: Upload Test Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: build/reports/tests/test
+
       - name: Remove secrets
         run: rm -rf src/main/resources/firebase
 

--- a/src/main/java/com/sparta/couponpop/common/exception/CommonErrorCode.java
+++ b/src/main/java/com/sparta/couponpop/common/exception/CommonErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum CommonErrorCode implements ErrorCode {
 
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다. 관리자에게 문의해주세요."),
-    FIREBASE_INITIALIZATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Firebase 초기화 중 오류가 발생했습니다.");
+    FIREBASE_INITIALIZATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Firebase 초기화 중 오류가 발생했습니다."),
+    REDIS_SCAN_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Redis Scan 작업 중 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/sparta/couponpop/common/redis/enums/RedisKeyProperties.java
+++ b/src/main/java/com/sparta/couponpop/common/redis/enums/RedisKeyProperties.java
@@ -1,0 +1,21 @@
+package com.sparta.couponpop.common.redis.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.Duration;
+
+@Getter
+@RequiredArgsConstructor
+public enum RedisKeyProperties {
+
+    LOCATION_MEMBER_DEVICE("fcm:v1:location:", "member:%d:device:%s", Duration.ofDays(1));
+
+    private final String keyPrefix;
+    private final String keyPattern;
+    private final Duration expiration;
+
+    public String getKey() {
+        return keyPrefix + keyPattern;
+    }
+}

--- a/src/main/java/com/sparta/couponpop/common/redis/service/RedisService.java
+++ b/src/main/java/com/sparta/couponpop/common/redis/service/RedisService.java
@@ -24,6 +24,8 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class RedisService {
 
+    private static final int DEFAULT_SCAN_COUNT = 1_000;
+
     private final RedisTemplate<String, Object> redisTemplate;
     private final ObjectMapper objectMapper;
 
@@ -50,13 +52,12 @@ public class RedisService {
      */
     public Set<String> scanKeysByPrefix(String prefix) {
         final String pattern = prefix + "*";
-        final int scanCount = 1_000;
 
         return redisTemplate.execute((RedisCallback<Set<String>>) connection -> {
             Set<String> results = new LinkedHashSet<>();
             ScanOptions options = ScanOptions.scanOptions()
                     .match(pattern)
-                    .count(scanCount)
+                    .count(DEFAULT_SCAN_COUNT)
                     .build();
 
             RedisKeyCommands redisKeyCommands = connection.keyCommands();

--- a/src/main/java/com/sparta/couponpop/common/redis/service/RedisService.java
+++ b/src/main/java/com/sparta/couponpop/common/redis/service/RedisService.java
@@ -1,0 +1,108 @@
+package com.sparta.couponpop.common.redis.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.couponpop.common.exception.CommonErrorCode;
+import com.sparta.couponpop.common.exception.GlobalException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.RedisKeyCommands;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    // 키-값을 저장
+    public void setKey(String key, Object value, Duration expirationInSeconds) {
+        redisTemplate.opsForValue().set(key, value, expirationInSeconds);
+    }
+
+    // 키가 존재하는지 확인
+    public boolean hasKey(String key) {
+        return redisTemplate.hasKey(key);
+    }
+
+    // 키 삭제
+    public boolean deleteKey(String key) {
+        return redisTemplate.delete(key);
+    }
+
+    /**
+     * 주어진 prefix로 시작하는 모든 키들을 스캔하여 집합으로 반환
+     *
+     * @param prefix 키 접두사
+     * @return 접두사로 시작하는 모든 키들의 집합
+     */
+    public Set<String> scanKeysByPrefix(String prefix) {
+        final String pattern = prefix + "*";
+        final int scanCount = 1_000;
+
+        return redisTemplate.execute((RedisCallback<Set<String>>) connection -> {
+            Set<String> results = new LinkedHashSet<>();
+            ScanOptions options = ScanOptions.scanOptions()
+                    .match(pattern)
+                    .count(scanCount)
+                    .build();
+
+            RedisKeyCommands redisKeyCommands = connection.keyCommands();
+            try (Cursor<byte[]> cursor = redisKeyCommands.scan(options)) {
+                while (cursor.hasNext()) {
+                    String key = new String(cursor.next(), StandardCharsets.UTF_8);
+                    results.add(key);
+                }
+            } catch (Exception e) {
+                throw new GlobalException(CommonErrorCode.REDIS_SCAN_FAILED);
+            }
+
+            return results;
+        });
+    }
+
+    /**
+     * 캐시 값들을 key 집합으로 조회하고 지정된 타입으로 변환하여 리스트로 반환
+     *
+     * @param keys 조회할 키들
+     * @param type 조회된 캐시 값들을 변환할 타입
+     * @param <T>  리스트로 반환할 캐시 값의 타입
+     * @return 조회된 캐시 값들의 리스트
+     */
+    public <T> List<T> fetchCacheValues(Set<String> keys, Class<T> type) {
+        if (keys.isEmpty()) {
+            return List.of();
+        }
+
+        List<Object> values = redisTemplate.opsForValue().multiGet(keys);
+        log.info("Redis에서 캐시 값을 조회했습니다. keysCount={}, fetchedCount={}, values={}", keys.size(), values != null ? values.size() : 0, values);
+        if (values == null || values.isEmpty()) {
+            return List.of();
+        }
+
+        List<T> result = new ArrayList<>();
+        for (Object value : values) {
+            if (value == null) {
+                continue;
+            }
+
+            T convertedValue = objectMapper.convertValue(value, type);
+            result.add(convertedValue);
+        }
+
+        return result;
+    }
+
+}

--- a/src/main/java/com/sparta/couponpop/common/redis/service/RedisService.java
+++ b/src/main/java/com/sparta/couponpop/common/redis/service/RedisService.java
@@ -44,6 +44,14 @@ public class RedisService {
         return redisTemplate.delete(key);
     }
 
+    // 키 집합 삭제
+    public long deleteKeys(Set<String> keys) {
+        if (keys.isEmpty()) {
+            return 0;
+        }
+        return redisTemplate.delete(keys);
+    }
+
     /**
      * 주어진 prefix로 시작하는 모든 키들을 스캔하여 집합으로 반환
      *

--- a/src/main/java/com/sparta/couponpop/domain/location/controller/LocationController.java
+++ b/src/main/java/com/sparta/couponpop/domain/location/controller/LocationController.java
@@ -1,0 +1,28 @@
+package com.sparta.couponpop.domain.location.controller;
+
+import com.sparta.couponpop.common.response.ApiResponse;
+import com.sparta.couponpop.common.security.annotation.CurrentMember;
+import com.sparta.couponpop.common.security.dto.AuthMember;
+import com.sparta.couponpop.domain.location.dto.request.CreateLocationRequest;
+import com.sparta.couponpop.domain.location.service.LocationService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class LocationController {
+
+    private final LocationService locationService;
+
+    @PostMapping("/api/v1/locations/current")
+    public ResponseEntity<ApiResponse<Void>> createLocation(@RequestBody @Valid CreateLocationRequest request,
+                                                            @CurrentMember AuthMember authMember) {
+        locationService.cacheLocation(request, authMember.id());
+        return ApiResponse.noContent();
+    }
+
+}

--- a/src/main/java/com/sparta/couponpop/domain/location/dto/cache/LocationCacheValue.java
+++ b/src/main/java/com/sparta/couponpop/domain/location/dto/cache/LocationCacheValue.java
@@ -1,0 +1,17 @@
+package com.sparta.couponpop.domain.location.dto.cache;
+
+import java.time.LocalDateTime;
+
+public record LocationCacheValue(
+        Long memberId,
+        String fcmToken,
+        String deviceIdentifier,
+        Double latitude,
+        Double longitude,
+        LocalDateTime cachedAt
+) {
+
+    public static LocationCacheValue of(Long memberId, String fcmToken, String deviceIdentifier, Double latitude, Double longitude, LocalDateTime cachedAt) {
+        return new LocationCacheValue(memberId, fcmToken, deviceIdentifier, latitude, longitude, cachedAt);
+    }
+}

--- a/src/main/java/com/sparta/couponpop/domain/location/dto/request/CreateLocationRequest.java
+++ b/src/main/java/com/sparta/couponpop/domain/location/dto/request/CreateLocationRequest.java
@@ -1,0 +1,25 @@
+package com.sparta.couponpop.domain.location.dto.request;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateLocationRequest(
+        @NotBlank(message = "FCM 토큰은 필수입니다.")
+        String fcmToken,
+        
+        @NotBlank(message = "디바이스 식별자는 필수입니다.")
+        String deviceIdentifier,
+
+        @NotNull(message = "위도는 필수입니다.")
+        @DecimalMin(value = "-90.0", message = "위도는 -90 이상이어야 합니다.")
+        @DecimalMax(value = "90.0", message = "위도는 90 이하이어야 합니다.")
+        Double latitude,
+
+        @NotNull(message = "경도는 필수입니다.")
+        @DecimalMin(value = "-180.0", message = "경도는 -180 이상이어야 합니다.")
+        @DecimalMax(value = "180.0", message = "경도는 180 이하이어야 합니다.")
+        Double longitude
+) {
+}

--- a/src/main/java/com/sparta/couponpop/domain/location/service/LocationService.java
+++ b/src/main/java/com/sparta/couponpop/domain/location/service/LocationService.java
@@ -1,0 +1,38 @@
+package com.sparta.couponpop.domain.location.service;
+
+import com.sparta.couponpop.common.exception.GlobalException;
+import com.sparta.couponpop.common.redis.enums.RedisKeyProperties;
+import com.sparta.couponpop.common.redis.service.RedisService;
+import com.sparta.couponpop.domain.location.dto.cache.LocationCacheValue;
+import com.sparta.couponpop.domain.location.dto.request.CreateLocationRequest;
+import com.sparta.couponpop.domain.member.entity.Member;
+import com.sparta.couponpop.domain.member.exception.MemberErrorCode;
+import com.sparta.couponpop.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LocationService {
+
+    private final MemberRepository memberRepository;
+    private final RedisService redisService;
+
+    public void cacheLocation(CreateLocationRequest request, Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GlobalException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        final LocalDateTime now = LocalDateTime.now();
+        final RedisKeyProperties keyProperties = RedisKeyProperties.LOCATION_MEMBER_DEVICE;
+
+        String locationKey = keyProperties.getKey().formatted(member.getId(), request.deviceIdentifier());
+        LocationCacheValue locationCacheValue = LocationCacheValue.of(member.getId(), request.fcmToken(), request.deviceIdentifier(), request.latitude(), request.longitude(), now);
+
+        redisService.setKey(locationKey, locationCacheValue, keyProperties.getExpiration());
+    }
+
+}

--- a/src/main/java/com/sparta/couponpop/domain/notification/constants/NotificationTemplates.java
+++ b/src/main/java/com/sparta/couponpop/domain/notification/constants/NotificationTemplates.java
@@ -14,4 +14,10 @@ public final class NotificationTemplates {
             만료기간: %s
             """;
 
+    // 위치 기반 이벤트 알림 템플릿
+    public static final String LOCATION_BASED_COUPON_EVENT_TITLE = "근처 %d개의 매장에서 쿠폰 이벤트가 진행 중입니다!";
+    public static final String LOCATION_BASED_COUPON_EVENT_BODY = """
+            근처 %d개의 매장에서 %d개의 쿠폰 이벤트가 진행 중입니다.
+            """;
+
 }

--- a/src/main/java/com/sparta/couponpop/domain/notification/controller/FcmTestController.java
+++ b/src/main/java/com/sparta/couponpop/domain/notification/controller/FcmTestController.java
@@ -51,4 +51,14 @@ public class FcmTestController {
         return ApiResponse.noContent();
     }
 
+    @PostMapping("fcm/test3")
+    public ResponseEntity<ApiResponse<Void>> sendLocationBasedCouponEventNotification() {
+        log.debug("[+] 위치 기반 쿠폰 이벤트 알림 푸시 메세지 전송");
+
+        // 위치 기반 쿠폰 이벤트 알림 테스트
+        notificationService.notifyLocationBasedCouponEvent();
+
+        return ApiResponse.noContent();
+    }
+
 }

--- a/src/main/java/com/sparta/couponpop/domain/notification/dto/payload/LocationBasedCouponEventNotificationPayload.java
+++ b/src/main/java/com/sparta/couponpop/domain/notification/dto/payload/LocationBasedCouponEventNotificationPayload.java
@@ -1,6 +1,0 @@
-package com.sparta.couponpop.domain.notification.dto.payload;
-
-public record LocationBasedCouponEventNotificationPayload(
-
-) {
-}

--- a/src/main/java/com/sparta/couponpop/domain/notification/service/sender/LocationBasedCouponEventNotificationSender.java
+++ b/src/main/java/com/sparta/couponpop/domain/notification/service/sender/LocationBasedCouponEventNotificationSender.java
@@ -40,6 +40,7 @@ public class LocationBasedCouponEventNotificationSender implements NotificationS
         String notificationTypeDescription = getType().getDescription();
         LocalDateTime now = LocalDateTime.now();
 
+        // TODO: https://github.com/CouponPop/coupon-pop-api/pull/91#discussion_r2450300987
         // 1. prefix로 위치 기반 캐시 키 조회
         String keyPrefix = RedisKeyProperties.LOCATION_MEMBER_DEVICE.getKeyPrefix();
         Set<String> locationKeys = redisService.scanKeysByPrefix(keyPrefix);

--- a/src/main/java/com/sparta/couponpop/domain/notification/service/sender/LocationBasedCouponEventNotificationSender.java
+++ b/src/main/java/com/sparta/couponpop/domain/notification/service/sender/LocationBasedCouponEventNotificationSender.java
@@ -1,31 +1,103 @@
 package com.sparta.couponpop.domain.notification.service.sender;
 
-import com.sparta.couponpop.domain.member.repository.MemberFcmTokenRepository;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.sparta.couponpop.common.redis.enums.RedisKeyProperties;
+import com.sparta.couponpop.common.redis.service.RedisService;
+import com.sparta.couponpop.domain.location.dto.cache.LocationCacheValue;
+import com.sparta.couponpop.domain.notification.constants.NotificationTemplates;
 import com.sparta.couponpop.domain.notification.dto.command.LocationBasedCouponEventNotificationCommand;
 import com.sparta.couponpop.domain.notification.enums.NotificationType;
 import com.sparta.couponpop.domain.notification.service.FcmSendService;
+import com.sparta.couponpop.domain.store.dto.response.StoreAndCouponEventCountProjection;
+import com.sparta.couponpop.domain.store.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class LocationBasedCouponEventNotificationSender implements NotificationSender<LocationBasedCouponEventNotificationCommand> {
 
-    private final MemberFcmTokenRepository memberFcmTokenRepository;
+    // 조회 반경
+    private static final double SEARCH_RADIUS_KM = 1.0;
+
     private final FcmSendService fcmSendService;
+    private final RedisService redisService;
+    private final StoreRepository storeRepository;
 
     @Override
     public NotificationType getType() {
         return NotificationType.LOCATION_BASED_EVENT;
     }
 
-    // TODO: 위치 기반 알림이니 Webpush는 불필요
     @Override
     public void send(LocationBasedCouponEventNotificationCommand command) {
-        String NotificationTypeDescription = getType().getDescription();
+        String notificationTypeDescription = getType().getDescription();
+        LocalDateTime now = LocalDateTime.now();
 
+        // 1. prefix로 위치 기반 캐시 키 조회
+        String keyPrefix = RedisKeyProperties.LOCATION_MEMBER_DEVICE.getKeyPrefix();
+        Set<String> locationKeys = redisService.scanKeysByPrefix(keyPrefix);
+        if (locationKeys.isEmpty()) {
+            log.info("위치 기반 캐시 키가 존재하지 않아 알림 전송을 건너뜁니다. keyPrefix={}", keyPrefix);
+            return;
+        }
+
+        log.info("위치 기반 캐시 키를 조회했습니다. keyPrefix={}, keys={}, count={}", keyPrefix, locationKeys, locationKeys.size());
+
+        // 2. 위치 기반 캐시 값 조회
+        List<LocationCacheValue> locationCacheValues = redisService.fetchCacheValues(locationKeys, LocationCacheValue.class);
+        if (locationCacheValues.isEmpty()) {
+            log.info("위치 기반 캐시 데이터가 비어 있어 알림 전송을 건너뜁니다. keyPrefix={}", keyPrefix);
+            return;
+        }
+
+        // 3. 캐시 값들을 순회
+        for (LocationCacheValue locationCacheValue : locationCacheValues) {
+            /*
+             * TODO
+             * - 비용이 큰 쿼리문을 for문으로 순회하며 실행중
+             * - M x N 문제 발생 예상하여 추후 개선 필요
+             */
+            // 4. 근처 매장수와 쿠폰이벤트수를 조회
+            StoreAndCouponEventCountProjection countProjection = storeRepository.findNearbyOpenStoreAndEventCount(
+                    locationCacheValue.latitude(),
+                    locationCacheValue.longitude(),
+                    SEARCH_RADIUS_KM,
+                    now
+            );
+
+            Long openStoreCount = countProjection.getOpenStoreCount();
+            Long activeCouponEventCount = countProjection.getActiveCouponEventCount();
+            log.info("근처 매장 및 쿠폰 이벤트 수를 조회했습니다. openStoreCount={}, activeCouponEventCount={}",
+                    openStoreCount, activeCouponEventCount);
+
+            if (openStoreCount == 0) {
+                log.info("근처에 오픈된 매장이 없어 알림 전송을 건너뜁니다. locationCacheValue={}", locationCacheValue);
+                continue;
+            }
+
+            if (activeCouponEventCount == 0) {
+                log.info("근처 매장에 활성화된 쿠폰 이벤트가 없어 알림 전송을 건너뜁니다. locationCacheValue={}", locationCacheValue);
+                continue;
+            }
+
+            // 5. FCM 토큰으로 푸시 알림 전송
+            String token = locationCacheValue.fcmToken();
+
+            String title = NotificationTemplates.LOCATION_BASED_COUPON_EVENT_TITLE.formatted(openStoreCount);
+            String body = NotificationTemplates.LOCATION_BASED_COUPON_EVENT_BODY.formatted(openStoreCount, activeCouponEventCount);
+
+            try {
+                fcmSendService.sendNotification(token, title, body);
+            } catch (FirebaseMessagingException e) {
+                log.error("{} 전송 중 오류가 발생했습니다. token={}, message={}", notificationTypeDescription, token, e.getMessage(), e);
+            }
+        }
     }
 }
-

--- a/src/main/java/com/sparta/couponpop/domain/notification/service/sender/LocationBasedCouponEventNotificationSender.java
+++ b/src/main/java/com/sparta/couponpop/domain/notification/service/sender/LocationBasedCouponEventNotificationSender.java
@@ -99,5 +99,9 @@ public class LocationBasedCouponEventNotificationSender implements NotificationS
                 log.error("{} 전송 중 오류가 발생했습니다. token={}, message={}", notificationTypeDescription, token, e.getMessage(), e);
             }
         }
+
+        // 6. Key들을 삭제한다.
+        long deletedCount = redisService.deleteKeys(locationKeys);
+        log.info("위치 기반 캐시 키들을 삭제했습니다. keyPrefix={}, deletedCount={}", keyPrefix, deletedCount);
     }
 }

--- a/src/main/java/com/sparta/couponpop/domain/store/dto/response/StoreAndCouponEventCountProjection.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/dto/response/StoreAndCouponEventCountProjection.java
@@ -1,0 +1,7 @@
+package com.sparta.couponpop.domain.store.dto.response;
+
+public interface StoreAndCouponEventCountProjection {
+    Long getOpenStoreCount();
+
+    Long getActiveCouponEventCount();
+}

--- a/src/main/java/com/sparta/couponpop/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/couponpop/domain/store/repository/StoreRepository.java
@@ -1,19 +1,22 @@
 package com.sparta.couponpop.domain.store.repository;
 
+import com.sparta.couponpop.domain.store.dto.response.StoreAndCouponEventCountProjection;
 import com.sparta.couponpop.domain.store.dto.response.StoreLocationProjection;
 import com.sparta.couponpop.domain.store.entity.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.Optional;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
 
     /**
      * 삭제된 매장을 포함하여 ID로 매장을 조회합니다.
      * 매장 삭제 시 권한 검증을 위해 사용됩니다.
+     *
      * @SQLRestriction을 무시하고 모든 매장을 조회합니다.
      */
     @Query(value = "SELECT * FROM stores WHERE id = :storeId", nativeQuery = true)
@@ -64,8 +67,53 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
             ORDER BY sub.distance ASC
             """, nativeQuery = true)
     List<StoreLocationProjection> findByLocation(@Param("lat") double latitude,
-                                              @Param("lng") double longitude,
-                                              @Param("radius") double radiusKm);
+                                                 @Param("lng") double longitude,
+                                                 @Param("radius") double radiusKm);
+
+    // TODO: 추후 개선 필요 (ES 등 외부 검색엔진 도입 검토)
+    @Query(value = """
+            SELECT 
+                COUNT(DISTINCT subStore.id) AS openStoreCount,
+                COUNT(ce.id) AS activeCouponEventCount
+            FROM (
+                SELECT 
+                    s.id,
+                    ST_Distance_Sphere(s.location, ST_SRID(POINT(:lng, :lat), 4326)) / 1000 AS distance,
+                    CASE WHEN DAYOFWEEK(:nowTs) IN (1, 7) THEN s.weekend_open_time ELSE s.weekday_open_time END AS open_time,
+                    CASE WHEN DAYOFWEEK(:nowTs) IN (1, 7) THEN s.weekend_close_time ELSE s.weekday_close_time END AS close_time
+                FROM stores s
+                WHERE s.deleted_at IS NULL
+            ) AS subStore
+            LEFT JOIN coupon_events ce 
+                ON ce.store_id = subStore.id
+                AND ce.coupon_event_status IN ('SCHEDULED', 'IN_PROGRESS')
+                AND ce.total_count > ce.issued_count
+            WHERE subStore.distance <= :radius
+                AND subStore.open_time IS NOT NULL
+                AND subStore.close_time IS NOT NULL
+                AND (
+                        -- 정상 구간(당일 마감)
+                        (
+                            subStore.open_time <= subStore.close_time
+                            AND (
+                                TIME(:nowTs) >= subStore.open_time
+                                AND TIME(:nowTs) <  subStore.close_time
+                            )
+                        )
+                        -- 심야 구간(익일 마감)
+                        OR (
+                            subStore.open_time > subStore.close_time
+                            AND (
+                                TIME(:nowTs) >= subStore.open_time
+                                OR TIME(:nowTs) < subStore.close_time
+                            )
+                        )
+                )
+            """, nativeQuery = true)
+    StoreAndCouponEventCountProjection findNearbyOpenStoreAndEventCount(@Param("lat") double latitude,
+                                                                        @Param("lng") double longitude,
+                                                                        @Param("radius") double radiusKm,
+                                                                        @Param("nowTs") LocalDateTime nowTs);
 
     List<Store> findByMemberIdOrderByCreatedAtDesc(Long memberId);
 

--- a/src/test/java/com/sparta/couponpop/domain/location/controller/LocationControllerTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/location/controller/LocationControllerTest.java
@@ -1,0 +1,128 @@
+package com.sparta.couponpop.domain.location.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.couponpop.common.security.JwtAuthenticationToken;
+import com.sparta.couponpop.common.security.JwtProvider;
+import com.sparta.couponpop.common.security.dto.AuthMember;
+import com.sparta.couponpop.domain.location.dto.request.CreateLocationRequest;
+import com.sparta.couponpop.domain.location.service.LocationService;
+import com.sparta.couponpop.domain.member.enums.MemberType;
+import org.junit.jupiter.api.*;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(LocationController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class LocationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private LocationService locationService;
+
+    @BeforeEach
+    void setUpSecurityContext() {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        AuthMember authMember = AuthMember.from(123L, "테스트사용자", MemberType.CUSTOMER);
+        Authentication authentication = new JwtAuthenticationToken(authMember);
+        context.setAuthentication(authentication);
+        SecurityContextHolder.setContext(context);
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/locations/current")
+    class CreateCurrentLocation {
+
+        private static final String URL = "/api/v1/locations/current";
+
+        @Test
+        @DisplayName("회원이 유효한 위치 정보를 전송하면 현재 위치를 캐시하고 204를 반환한다.")
+        void createLocation_success_validRequest() throws Exception {
+            // given
+            CreateLocationRequest request = new CreateLocationRequest(
+                    "sample-fcm-token",
+                    "device-123",
+                    37.5665,
+                    126.9780
+            );
+
+            willDoNothing().given(locationService).cacheLocation(any(CreateLocationRequest.class), anyLong());
+
+            // when
+            mockMvc.perform(
+                            post(URL)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request))
+                    )
+                    .andDo(print())
+                    .andExpect(status().isNoContent());
+
+            // then
+            ArgumentCaptor<CreateLocationRequest> requestCaptor = ArgumentCaptor.forClass(CreateLocationRequest.class);
+            ArgumentCaptor<Long> memberIdCaptor = ArgumentCaptor.forClass(Long.class);
+            verify(locationService).cacheLocation(requestCaptor.capture(), memberIdCaptor.capture());
+
+            CreateLocationRequest capturedRequest = requestCaptor.getValue();
+            assertThat(capturedRequest.fcmToken()).isEqualTo("sample-fcm-token");
+            assertThat(capturedRequest.deviceIdentifier()).isEqualTo("device-123");
+            assertThat(capturedRequest.latitude()).isEqualTo(37.5665);
+            assertThat(capturedRequest.longitude()).isEqualTo(126.9780);
+            assertThat(memberIdCaptor.getValue()).isEqualTo(123L);
+        }
+
+        @Test
+        @DisplayName("위도 값이 허용 범위를 벗어나면 현재 위치 저장 요청이 400을 반환한다.")
+        void createLocation_fail_invalidLatitude() throws Exception {
+            // given
+            CreateLocationRequest request = new CreateLocationRequest(
+                    "sample-fcm-token",
+                    "device-123",
+                    95.0,
+                    126.9780
+            );
+
+            // when & then
+            mockMvc.perform(
+                            post(URL)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request))
+                    )
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error.message").value("위도는 90 이하이어야 합니다."));
+
+            verify(locationService, never()).cacheLocation(any(CreateLocationRequest.class), anyLong());
+        }
+    }
+}

--- a/src/test/java/com/sparta/couponpop/domain/location/controller/LocationControllerTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/location/controller/LocationControllerTest.java
@@ -1,6 +1,7 @@
 package com.sparta.couponpop.domain.location.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.couponpop.common.security.JwtAuthFilter;
 import com.sparta.couponpop.common.security.JwtAuthenticationToken;
 import com.sparta.couponpop.common.security.JwtProvider;
 import com.sparta.couponpop.common.security.dto.AuthMember;
@@ -42,6 +43,9 @@ class LocationControllerTest {
 
     @MockitoBean
     private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private JwtAuthFilter jwtAuthFilter;
 
     @MockitoBean
     private LocationService locationService;

--- a/src/test/java/com/sparta/couponpop/domain/location/service/LocationServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/location/service/LocationServiceTest.java
@@ -1,0 +1,99 @@
+package com.sparta.couponpop.domain.location.service;
+
+import com.sparta.couponpop.common.exception.GlobalException;
+import com.sparta.couponpop.common.redis.enums.RedisKeyProperties;
+import com.sparta.couponpop.common.redis.service.RedisService;
+import com.sparta.couponpop.domain.location.dto.cache.LocationCacheValue;
+import com.sparta.couponpop.domain.location.dto.request.CreateLocationRequest;
+import com.sparta.couponpop.domain.member.entity.Member;
+import com.sparta.couponpop.domain.member.exception.MemberErrorCode;
+import com.sparta.couponpop.domain.member.repository.MemberRepository;
+import com.sparta.couponpop.utils.TestUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class LocationServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private RedisService redisService;
+
+    private LocationService locationService;
+
+    @BeforeEach
+    void setUp() {
+        locationService = new LocationService(memberRepository, redisService);
+    }
+
+    @Nested
+    @DisplayName("회원 위치 캐시 저장")
+    class CacheLocation {
+
+        @Test
+        @DisplayName("회원이 존재하면 위치 정보를 Redis에 저장한다")
+        void cacheLocation_success_memberExists() {
+            // given
+            Long memberId = 1L;
+            Member member = TestUtils.createEntity(Member.class, Map.of("id", memberId));
+            CreateLocationRequest request = new CreateLocationRequest("sample-fcm-token", "device-123", 37.5665, 126.9780);
+            LocalDateTime before = LocalDateTime.now();
+            given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+            ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+            ArgumentCaptor<LocationCacheValue> valueCaptor = ArgumentCaptor.forClass(LocationCacheValue.class);
+            ArgumentCaptor<Duration> expirationCaptor = ArgumentCaptor.forClass(Duration.class);
+
+            // when
+            locationService.cacheLocation(request, memberId);
+            LocalDateTime after = LocalDateTime.now();
+
+            // then
+            then(redisService).should().setKey(keyCaptor.capture(), valueCaptor.capture(), expirationCaptor.capture());
+            String expectedKey = RedisKeyProperties.LOCATION_MEMBER_DEVICE.getKey().formatted(memberId, request.deviceIdentifier());
+            assertThat(keyCaptor.getValue()).isEqualTo(expectedKey);
+            LocationCacheValue cacheValue = valueCaptor.getValue();
+            assertThat(cacheValue.memberId()).isEqualTo(memberId);
+            assertThat(cacheValue.fcmToken()).isEqualTo(request.fcmToken());
+            assertThat(cacheValue.deviceIdentifier()).isEqualTo(request.deviceIdentifier());
+            assertThat(cacheValue.latitude()).isEqualTo(request.latitude());
+            assertThat(cacheValue.longitude()).isEqualTo(request.longitude());
+            assertThat(cacheValue.cachedAt()).isBetween(before, after);
+            assertThat(expirationCaptor.getValue()).isEqualTo(RedisKeyProperties.LOCATION_MEMBER_DEVICE.getExpiration());
+        }
+
+        @Test
+        @DisplayName("회원이 존재하지 않으면 예외를 던진다")
+        void cacheLocation_fail_memberNotFound() {
+            // given
+            Long memberId = 99L;
+            CreateLocationRequest request = new CreateLocationRequest("sample-fcm-token", "device-123", 37.5665, 126.9780);
+            given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> locationService.cacheLocation(request, memberId))
+                    .isInstanceOf(GlobalException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(MemberErrorCode.MEMBER_NOT_FOUND);
+
+            then(redisService).shouldHaveNoInteractions();
+        }
+    }
+}

--- a/src/test/java/com/sparta/couponpop/domain/member/controller/MemberFcmTokenControllerTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/member/controller/MemberFcmTokenControllerTest.java
@@ -8,9 +8,7 @@ import com.sparta.couponpop.common.security.dto.AuthMember;
 import com.sparta.couponpop.domain.member.dto.request.MemberFcmTokenRequest;
 import com.sparta.couponpop.domain.member.enums.MemberType;
 import com.sparta.couponpop.domain.member.service.MemberFcmTokenService;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -56,27 +54,38 @@ class MemberFcmTokenControllerTest {
         SecurityContextHolder.setContext(context);
     }
 
-    @Test
-    @DisplayName("회원 FCM 토큰 생성 및 갱신 - 성공")
-    void upsertMemberFcmToken_success() throws Exception {
-        // given
-        MemberFcmTokenRequest request = MemberFcmTokenRequest.builder()
-                .fcmToken("sample_fcm_token")
-                .deviceType("ANDROID")
-                .deviceIdentifier("device-123")
-                .build();
-
-        willDoNothing().given(memberFcmTokenService).upsertTokenForMember(any(MemberFcmTokenRequest.class), anyLong());
-
-        // when & then
-        mockMvc.perform(
-                        post("/api/v1/members/fcm-token")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(request))
-                )
-                .andDo(print())
-                .andExpect(status().isNoContent());
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
     }
 
+    @Nested
+    @DisplayName("POST /api/v1/members/fcm-token")
+    class UpsertMemberFcmToken {
+
+        private static final String URL = "/api/v1/members/fcm-token";
+
+        @Test
+        @DisplayName("회원 FCM 토큰 생성 및 갱신 - 성공")
+        void upsertMemberFcmToken_success() throws Exception {
+            // given
+            MemberFcmTokenRequest request = MemberFcmTokenRequest.builder()
+                    .fcmToken("sample_fcm_token")
+                    .deviceType("ANDROID")
+                    .deviceIdentifier("device-123")
+                    .build();
+
+            willDoNothing().given(memberFcmTokenService).upsertTokenForMember(any(MemberFcmTokenRequest.class), anyLong());
+
+            // when & then
+            mockMvc.perform(
+                            post(URL)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request))
+                    )
+                    .andDo(print())
+                    .andExpect(status().isNoContent());
+        }
+    }
 
 }

--- a/src/test/java/com/sparta/couponpop/domain/notification/service/sender/LocationBasedCouponEventNotificationSenderTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/notification/service/sender/LocationBasedCouponEventNotificationSenderTest.java
@@ -58,6 +58,7 @@ class LocationBasedCouponEventNotificationSenderTest {
             // then
             then(redisService).should().scanKeysByPrefix(keyPrefix);
             then(redisService).should(never()).fetchCacheValues(anySet(), eq(LocationCacheValue.class));
+            then(redisService).should(never()).deleteKeys(anySet());
             then(storeRepository).shouldHaveNoInteractions();
             then(fcmSendService).shouldHaveNoInteractions();
         }
@@ -77,6 +78,7 @@ class LocationBasedCouponEventNotificationSenderTest {
             // then
             then(redisService).should().scanKeysByPrefix(keyPrefix);
             then(redisService).should().fetchCacheValues(locationKeys, LocationCacheValue.class);
+            then(redisService).should(never()).deleteKeys(anySet());
             then(storeRepository).shouldHaveNoInteractions();
             then(fcmSendService).shouldHaveNoInteractions();
         }
@@ -114,6 +116,7 @@ class LocationBasedCouponEventNotificationSenderTest {
                     eq(1.0),
                     any(LocalDateTime.class)
             );
+            then(redisService).should().deleteKeys(locationKeys);
             then(fcmSendService).should(never()).sendNotification(anyString(), anyString(), anyString());
         }
 
@@ -150,6 +153,7 @@ class LocationBasedCouponEventNotificationSenderTest {
                     eq(1.0),
                     any(LocalDateTime.class)
             );
+            then(redisService).should().deleteKeys(locationKeys);
             then(fcmSendService).should(never()).sendNotification(anyString(), anyString(), anyString());
         }
 
@@ -185,6 +189,7 @@ class LocationBasedCouponEventNotificationSenderTest {
             sender.send(LocationBasedCouponEventNotificationCommand.of());
 
             // then
+            then(redisService).should().deleteKeys(locationKeys);
             then(fcmSendService).should().sendNotification(cacheValue.fcmToken(), expectedTitle, expectedBody);
         }
 
@@ -218,6 +223,8 @@ class LocationBasedCouponEventNotificationSenderTest {
             // when & then
             assertThatCode(() -> sender.send(LocationBasedCouponEventNotificationCommand.of()))
                     .doesNotThrowAnyException();
+
+            then(redisService).should().deleteKeys(locationKeys);
         }
 
         private StoreAndCouponEventCountProjection projection(long openStoreCount, long activeCouponEventCount) {

--- a/src/test/java/com/sparta/couponpop/domain/notification/service/sender/LocationBasedCouponEventNotificationSenderTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/notification/service/sender/LocationBasedCouponEventNotificationSenderTest.java
@@ -1,0 +1,237 @@
+package com.sparta.couponpop.domain.notification.service.sender;
+
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.sparta.couponpop.common.redis.enums.RedisKeyProperties;
+import com.sparta.couponpop.common.redis.service.RedisService;
+import com.sparta.couponpop.domain.location.dto.cache.LocationCacheValue;
+import com.sparta.couponpop.domain.notification.constants.NotificationTemplates;
+import com.sparta.couponpop.domain.notification.dto.command.LocationBasedCouponEventNotificationCommand;
+import com.sparta.couponpop.domain.notification.service.FcmSendService;
+import com.sparta.couponpop.domain.store.dto.response.StoreAndCouponEventCountProjection;
+import com.sparta.couponpop.domain.store.repository.StoreRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class LocationBasedCouponEventNotificationSenderTest {
+
+    @Mock
+    private FcmSendService fcmSendService;
+
+    @Mock
+    private RedisService redisService;
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @InjectMocks
+    private LocationBasedCouponEventNotificationSender sender;
+
+    @Nested
+    @DisplayName("위치 기반 쿠폰 이벤트 알림 전송")
+    class Send {
+
+        @Test
+        @DisplayName("위치 기반 캐시 키가 없으면 전송을 건너뛴다")
+        void send_skip_locationCacheKeyEmpty() {
+            // given
+            String keyPrefix = RedisKeyProperties.LOCATION_MEMBER_DEVICE.getKeyPrefix();
+            given(redisService.scanKeysByPrefix(keyPrefix)).willReturn(Set.of());
+
+            // when
+            sender.send(LocationBasedCouponEventNotificationCommand.of());
+
+            // then
+            then(redisService).should().scanKeysByPrefix(keyPrefix);
+            then(redisService).should(never()).fetchCacheValues(anySet(), eq(LocationCacheValue.class));
+            then(storeRepository).shouldHaveNoInteractions();
+            then(fcmSendService).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("캐시 값이 비어 있으면 전송을 건너뛴다")
+        void send_skip_locationCacheValueEmpty() {
+            // given
+            String keyPrefix = RedisKeyProperties.LOCATION_MEMBER_DEVICE.getKeyPrefix();
+            Set<String> locationKeys = Set.of("fcm:v1:location:member:1:device:abc");
+            given(redisService.scanKeysByPrefix(keyPrefix)).willReturn(locationKeys);
+            given(redisService.fetchCacheValues(locationKeys, LocationCacheValue.class)).willReturn(List.of());
+
+            // when
+            sender.send(LocationBasedCouponEventNotificationCommand.of());
+
+            // then
+            then(redisService).should().scanKeysByPrefix(keyPrefix);
+            then(redisService).should().fetchCacheValues(locationKeys, LocationCacheValue.class);
+            then(storeRepository).shouldHaveNoInteractions();
+            then(fcmSendService).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("근처 매장이 없으면 전송을 건너뛴다")
+        void send_skip_noOpenStore() throws FirebaseMessagingException {
+            // given
+            String keyPrefix = RedisKeyProperties.LOCATION_MEMBER_DEVICE.getKeyPrefix();
+            Set<String> locationKeys = Set.of("fcm:v1:location:member:2:device:def");
+            LocationCacheValue cacheValue = LocationCacheValue.of(
+                    1L,
+                    "token-no-store",
+                    "device-def",
+                    37.5665,
+                    126.9780,
+                    LocalDateTime.of(2024, 1, 1, 12, 0)
+            );
+            given(redisService.scanKeysByPrefix(keyPrefix)).willReturn(locationKeys);
+            given(redisService.fetchCacheValues(locationKeys, LocationCacheValue.class)).willReturn(List.of(cacheValue));
+            given(storeRepository.findNearbyOpenStoreAndEventCount(
+                    eq(cacheValue.latitude()),
+                    eq(cacheValue.longitude()),
+                    eq(1.0),
+                    any(LocalDateTime.class)
+            )).willReturn(projection(0L, 3L));
+
+            // when
+            sender.send(LocationBasedCouponEventNotificationCommand.of());
+
+            // then
+            then(storeRepository).should().findNearbyOpenStoreAndEventCount(
+                    eq(cacheValue.latitude()),
+                    eq(cacheValue.longitude()),
+                    eq(1.0),
+                    any(LocalDateTime.class)
+            );
+            then(fcmSendService).should(never()).sendNotification(anyString(), anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("활성 쿠폰 이벤트가 없으면 전송을 건너뛴다")
+        void send_skip_noActiveCouponEvent() throws FirebaseMessagingException {
+            // given
+            String keyPrefix = RedisKeyProperties.LOCATION_MEMBER_DEVICE.getKeyPrefix();
+            Set<String> locationKeys = Set.of("fcm:v1:location:member:3:device:ghi");
+            LocationCacheValue cacheValue = LocationCacheValue.of(
+                    2L,
+                    "token-no-event",
+                    "device-ghi",
+                    35.1796,
+                    129.0756,
+                    LocalDateTime.of(2024, 2, 1, 9, 0)
+            );
+            given(redisService.scanKeysByPrefix(keyPrefix)).willReturn(locationKeys);
+            given(redisService.fetchCacheValues(locationKeys, LocationCacheValue.class)).willReturn(List.of(cacheValue));
+            given(storeRepository.findNearbyOpenStoreAndEventCount(
+                    eq(cacheValue.latitude()),
+                    eq(cacheValue.longitude()),
+                    eq(1.0),
+                    any(LocalDateTime.class)
+            )).willReturn(projection(5L, 0L));
+
+            // when
+            sender.send(LocationBasedCouponEventNotificationCommand.of());
+
+            // then
+            then(storeRepository).should().findNearbyOpenStoreAndEventCount(
+                    eq(cacheValue.latitude()),
+                    eq(cacheValue.longitude()),
+                    eq(1.0),
+                    any(LocalDateTime.class)
+            );
+            then(fcmSendService).should(never()).sendNotification(anyString(), anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("조건이 충족되면 FCM 알림을 전송한다")
+        void send_success_sendNotification() throws FirebaseMessagingException {
+            // given
+            String keyPrefix = RedisKeyProperties.LOCATION_MEMBER_DEVICE.getKeyPrefix();
+            Set<String> locationKeys = Set.of("fcm:v1:location:member:4:device:jkl");
+            LocationCacheValue cacheValue = LocationCacheValue.of(
+                    3L,
+                    "token-success",
+                    "device-jkl",
+                    37.1234,
+                    127.5678,
+                    LocalDateTime.of(2024, 3, 1, 15, 30)
+            );
+            long openStoreCount = 4L;
+            long activeEventCount = 6L;
+            given(redisService.scanKeysByPrefix(keyPrefix)).willReturn(locationKeys);
+            given(redisService.fetchCacheValues(locationKeys, LocationCacheValue.class)).willReturn(List.of(cacheValue));
+            given(storeRepository.findNearbyOpenStoreAndEventCount(
+                    eq(cacheValue.latitude()),
+                    eq(cacheValue.longitude()),
+                    eq(1.0),
+                    any(LocalDateTime.class)
+            )).willReturn(projection(openStoreCount, activeEventCount));
+
+            String expectedTitle = NotificationTemplates.LOCATION_BASED_COUPON_EVENT_TITLE.formatted(openStoreCount);
+            String expectedBody = NotificationTemplates.LOCATION_BASED_COUPON_EVENT_BODY.formatted(openStoreCount, activeEventCount);
+
+            // when
+            sender.send(LocationBasedCouponEventNotificationCommand.of());
+
+            // then
+            then(fcmSendService).should().sendNotification(cacheValue.fcmToken(), expectedTitle, expectedBody);
+        }
+
+        @Test
+        @DisplayName("FCM 전송 중 예외가 발생해도 예외를 전파하지 않는다")
+        void send_ignoreException_fcmSendFails() throws FirebaseMessagingException {
+            // given
+            String keyPrefix = RedisKeyProperties.LOCATION_MEMBER_DEVICE.getKeyPrefix();
+            Set<String> locationKeys = Set.of("fcm:v1:location:member:5:device:mno");
+            LocationCacheValue cacheValue = LocationCacheValue.of(
+                    4L,
+                    "token-fail",
+                    "device-mno",
+                    33.4996,
+                    126.5312,
+                    LocalDateTime.of(2024, 4, 1, 8, 0)
+            );
+            given(redisService.scanKeysByPrefix(keyPrefix)).willReturn(locationKeys);
+            given(redisService.fetchCacheValues(locationKeys, LocationCacheValue.class)).willReturn(List.of(cacheValue));
+            given(storeRepository.findNearbyOpenStoreAndEventCount(
+                    eq(cacheValue.latitude()),
+                    eq(cacheValue.longitude()),
+                    eq(1.0),
+                    any(LocalDateTime.class)
+            )).willReturn(projection(2L, 1L));
+
+            willThrow(FirebaseMessagingException.class)
+                    .given(fcmSendService)
+                    .sendNotification(eq(cacheValue.fcmToken()), anyString(), anyString());
+
+            // when & then
+            assertThatCode(() -> sender.send(LocationBasedCouponEventNotificationCommand.of()))
+                    .doesNotThrowAnyException();
+        }
+
+        private StoreAndCouponEventCountProjection projection(long openStoreCount, long activeCouponEventCount) {
+            return new StoreAndCouponEventCountProjection() {
+                @Override
+                public Long getOpenStoreCount() {
+                    return openStoreCount;
+                }
+
+                @Override
+                public Long getActiveCouponEventCount() {
+                    return activeCouponEventCount;
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 **연관된 이슈**
> close #이슈번호
- related to #21 

<br>

## 📝 **작업 내용**

### 회원 기기별 위도/경도 FCM 토큰 저장 API
- `POST /api/v1/locations/current`
- Redis 캐시(`fcm:v1:location:member:%d:device:%s`)로 저장 하도록 LocationService, LocationCacheValue를 구현

### Redis 키 스캔 및 다건 조회 서비스 로직 추가
- RedisService
   - scanKeysByPrefix
   - fetchCacheValues

<br>

- StoreRepository에 반경 1km 내 오픈 매장 수와 활성 쿠폰 이벤트 수를 계산하는 native 쿼리(`findNearbyOpenStoreAndEventCount`)를 추가해 알림 조건 판단에 활용
- 위치 기반 이벤트 전용 `Sender(LocationBasedCouponEventNotificationSender)`가 캐시 데이터를 순회하며 조건 충족 시 FCM을 발송하도록 구현
- 단위 테스트 추가

<br>

## 📸 **스크린샷 (선택)**

### Redis `LocationCacheValue` 예시
<img width="1469" height="365" alt="image" src="https://github.com/user-attachments/assets/8667e7f9-38af-499d-aac1-a5cde2e9794b" />


<br>
