### PR TITLE
feat: 회원 탈퇴 API 구현

### DIFF
--- a/src/main/java/com/sparta/couponpop/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/couponpop/domain/auth/controller/AuthController.java
@@ -6,6 +6,7 @@ import com.sparta.couponpop.common.security.dto.AuthMember;
 import com.sparta.couponpop.domain.auth.dto.request.LoginRequest;
 import com.sparta.couponpop.domain.auth.dto.request.LogoutRequest;
 import com.sparta.couponpop.domain.auth.dto.request.SignUpRequest;
+import com.sparta.couponpop.domain.auth.dto.request.WithdrawRequest;
 import com.sparta.couponpop.domain.auth.dto.response.LoginResponse;
 import com.sparta.couponpop.domain.auth.dto.response.SignUpResponse;
 import com.sparta.couponpop.domain.auth.service.AuthService;
@@ -39,12 +40,22 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
-    @PreAuthorize("isAuthenticated()") // auth는 모두 접근이므로, 로그아웃은 인증된 사용자만 접근 가능
+    @PreAuthorize("isAuthenticated()") // auth는 모두 접근가능하므로, 로그아웃은 인증된 사용자만 접근 가능
     public ResponseEntity<ApiResponse<Void>> logout(@RequestHeader("Authorization") String authorizationHeader,
-                                                    @Valid @RequestBody LogoutRequest logoutRequest,
-                                                    @CurrentMember AuthMember authMember) {
+                                                    @CurrentMember AuthMember authMember,
+                                                    @Valid @RequestBody LogoutRequest logoutRequest) {
 
         authService.logout(authorizationHeader, logoutRequest, authMember);
+        return ApiResponse.noContent();
+    }
+
+    @DeleteMapping("/withdraw")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<Void>> withdraw(@RequestHeader("Authorization") String authorizationHeader,
+                                                      @CurrentMember AuthMember authMember,
+                                                      @RequestBody WithdrawRequest withdrawRequest) {
+
+        authService.withdraw(authorizationHeader, authMember, withdrawRequest);
         return ApiResponse.noContent();
     }
 }

--- a/src/main/java/com/sparta/couponpop/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/couponpop/domain/auth/controller/AuthController.java
@@ -53,7 +53,7 @@ public class AuthController {
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse<Void>> withdraw(@RequestHeader("Authorization") String authorizationHeader,
                                                       @CurrentMember AuthMember authMember,
-                                                      @RequestBody WithdrawRequest withdrawRequest) {
+                                                      @Valid @RequestBody WithdrawRequest withdrawRequest) {
 
         authService.withdraw(authorizationHeader, authMember, withdrawRequest);
         return ApiResponse.noContent();

--- a/src/main/java/com/sparta/couponpop/domain/auth/dto/request/WithdrawRequest.java
+++ b/src/main/java/com/sparta/couponpop/domain/auth/dto/request/WithdrawRequest.java
@@ -1,0 +1,10 @@
+package com.sparta.couponpop.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record WithdrawRequest(
+
+        @NotBlank
+        String fcmToken
+) {
+}

--- a/src/main/java/com/sparta/couponpop/domain/auth/event/TokenBlacklistEvent.java
+++ b/src/main/java/com/sparta/couponpop/domain/auth/event/TokenBlacklistEvent.java
@@ -1,0 +1,11 @@
+package com.sparta.couponpop.domain.auth.event;
+
+public record TokenBlacklistEvent(
+        String token,
+        long expirationMillis
+) {
+
+    public static TokenBlacklistEvent of(String token, long expirationMillis) {
+        return new TokenBlacklistEvent(token, expirationMillis);
+    }
+}

--- a/src/main/java/com/sparta/couponpop/domain/auth/listener/TokenBlacklistEventListener.java
+++ b/src/main/java/com/sparta/couponpop/domain/auth/listener/TokenBlacklistEventListener.java
@@ -23,6 +23,6 @@ public class TokenBlacklistEventListener {
     public void handleTokenBlacklist(TokenBlacklistEvent event) {
 
         tokenBlacklistService.blacklistToken(event.token(), event.expirationMillis());
-        log.debug("[publishBlacklistTokenEvent] 토큰 블랙리스트 이벤트 수행 완료 - token={}", event.token());
+        log.debug("[handleTokenBlacklist] 토큰 블랙리스트 이벤트 수행 완료 - token={}", event.token());
     }
 }

--- a/src/main/java/com/sparta/couponpop/domain/auth/listener/TokenBlacklistEventListener.java
+++ b/src/main/java/com/sparta/couponpop/domain/auth/listener/TokenBlacklistEventListener.java
@@ -1,0 +1,28 @@
+package com.sparta.couponpop.domain.auth.listener;
+
+import com.sparta.couponpop.domain.auth.event.TokenBlacklistEvent;
+import com.sparta.couponpop.domain.auth.service.TokenBlacklistService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TokenBlacklistEventListener {
+
+    private final TokenBlacklistService tokenBlacklistService;
+
+    /**
+     * 회원 탈퇴의 DB 작업이 롤백되면 JWT 만료는 실행되지 않도록
+     * 트랜잭션 커밋 이후에 JWT 블랙리스트 작업을 수행합니다.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleTokenBlacklist(TokenBlacklistEvent event) {
+
+        tokenBlacklistService.blacklistToken(event.token(), event.expirationMillis());
+        log.debug("[publishBlacklistTokenEvent] 토큰 블랙리스트 이벤트 수행 완료 - token={}", event.token());
+    }
+}

--- a/src/main/java/com/sparta/couponpop/domain/auth/repository/InMemoryTokenBlacklistRepository.java
+++ b/src/main/java/com/sparta/couponpop/domain/auth/repository/InMemoryTokenBlacklistRepository.java
@@ -3,6 +3,10 @@ package com.sparta.couponpop.domain.auth.repository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -16,7 +20,11 @@ public class InMemoryTokenBlacklistRepository implements TokenBlacklistRepositor
     public void save(String token, long expirationMillis) {
 
         blacklist.put(token, expirationMillis);
-        log.info("[Blacklist Repository] Blacklist 추가 | token: {}, 잔여 시간: {}", token, expirationMillis);
+
+        Instant instant = Instant.ofEpochMilli(expirationMillis);
+        LocalDateTime dateTime = LocalDateTime.ofInstant(instant, ZoneId.of("Asia/Seoul"));
+        String formatted = dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+        log.info("[Blacklist Repository] Blacklist 추가 | token: {}, 만료 시각: {}", token, formatted);
     }
 
     @Override

--- a/src/main/java/com/sparta/couponpop/domain/auth/service/AuthService.java
+++ b/src/main/java/com/sparta/couponpop/domain/auth/service/AuthService.java
@@ -6,31 +6,39 @@ import com.sparta.couponpop.common.security.dto.AuthMember;
 import com.sparta.couponpop.domain.auth.dto.request.LoginRequest;
 import com.sparta.couponpop.domain.auth.dto.request.LogoutRequest;
 import com.sparta.couponpop.domain.auth.dto.request.SignUpRequest;
+import com.sparta.couponpop.domain.auth.dto.request.WithdrawRequest;
 import com.sparta.couponpop.domain.auth.dto.response.LoginResponse;
 import com.sparta.couponpop.domain.auth.dto.response.SignUpResponse;
+import com.sparta.couponpop.domain.auth.event.TokenBlacklistEvent;
 import com.sparta.couponpop.domain.auth.exception.AuthErrorCode;
 import com.sparta.couponpop.domain.member.entity.Member;
-import com.sparta.couponpop.domain.member.entity.MemberFcmToken;
 import com.sparta.couponpop.domain.member.exception.MemberErrorCode;
 import com.sparta.couponpop.domain.member.repository.MemberFcmTokenRepository;
 import com.sparta.couponpop.domain.member.repository.MemberRepository;
+import com.sparta.couponpop.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthService {
 
-    private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
+
+    private final MemberService memberService;
     private final TokenBlacklistService tokenBlacklistService;
+    private final MemberRepository memberRepository;
     private final MemberFcmTokenRepository memberFcmTokenRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public SignUpResponse signUp(SignUpRequest signUpRequest) {
@@ -84,29 +92,50 @@ public class AuthService {
     @Transactional
     public void logout(String authorizationHeader, LogoutRequest logoutRequest, AuthMember authMember) {
 
-        expireToken(authorizationHeader);
+        String resolvedToken = extractToken(authorizationHeader);
+        long expirationMillis = jwtProvider.getExpirationMillis(resolvedToken);
+
+        blacklistToken(resolvedToken, expirationMillis);
         expireFcmToken(authMember.id(), logoutRequest.fcmToken());
     }
 
-    // 로그아웃, 회원 탈퇴 시 블랙리스트 추가하여 토큰 만료 처리
-    private void expireToken(String authorizationHeader) {
+    // 회원 탈퇴가 되면 토큰만료 이벤트 발행, 회원탈퇴가 되지 않으면 롤백
+    @Transactional
+    public void withdraw(String authorizationHeader, AuthMember authMember, WithdrawRequest withdrawRequest) {
 
-        String token = jwtProvider.resolveToken(authorizationHeader);
-        if (token == null) {
-            throw new GlobalException(AuthErrorCode.INVALID_TOKEN);
-        }
+        String resolvedToken = extractToken(authorizationHeader);
+        long expirationMillis = jwtProvider.getExpirationMillis(resolvedToken);
 
-        long expirationMillis = jwtProvider.getExpirationMillis(token);
+        Member memberToWithdraw = memberService.findMemberById(authMember.id());
 
+        memberToWithdraw.withdraw();
+        expireFcmToken(memberToWithdraw.getId(), withdrawRequest.fcmToken());
+        publishBlacklistTokenEvent(resolvedToken, expirationMillis);
+    }
+
+    // 즉시 블랙리스트 추가
+    private void blacklistToken(String token, long expirationMillis) {
         tokenBlacklistService.blacklistToken(token, expirationMillis);
     }
 
+    // 블랙리스트 이벤트 발행
+    private void publishBlacklistTokenEvent(String token, long expirationMillis) {
+
+        TokenBlacklistEvent event = TokenBlacklistEvent.of(token, expirationMillis);
+        eventPublisher.publishEvent(event);
+        log.debug("[publishBlacklistTokenEvent] 토큰 블랙리스트 이벤트 발행 - token={}", token);
+    }
+
+    // FCM 토큰 삭제는 실패하더라도 전체 작업이 롤백되지는 않도록 ifPresent 사용
     private void expireFcmToken(Long memberId, String fcmToken) {
 
-        MemberFcmToken memberFcmToken = memberFcmTokenRepository
+        memberFcmTokenRepository
                 .findByMemberIdAndFcmToken(memberId, fcmToken)
-                .orElseThrow(() -> new GlobalException(MemberErrorCode.MEMBER_FCM_TOKEN_NOT_FOUND));
+                .ifPresent(memberFcmTokenRepository::delete);
+    }
 
-        memberFcmTokenRepository.delete(memberFcmToken);
+    private String extractToken(String authorizationHeader) {
+        return Optional.ofNullable(jwtProvider.resolveToken(authorizationHeader))
+                .orElseThrow(() -> new GlobalException(AuthErrorCode.INVALID_TOKEN));
     }
 }

--- a/src/main/java/com/sparta/couponpop/domain/auth/service/AuthService.java
+++ b/src/main/java/com/sparta/couponpop/domain/auth/service/AuthService.java
@@ -15,7 +15,6 @@ import com.sparta.couponpop.domain.member.entity.Member;
 import com.sparta.couponpop.domain.member.exception.MemberErrorCode;
 import com.sparta.couponpop.domain.member.repository.MemberFcmTokenRepository;
 import com.sparta.couponpop.domain.member.repository.MemberRepository;
-import com.sparta.couponpop.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -34,10 +33,9 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
 
-    private final MemberService memberService;
-    private final TokenBlacklistService tokenBlacklistService;
     private final MemberRepository memberRepository;
     private final MemberFcmTokenRepository memberFcmTokenRepository;
+    private final TokenBlacklistService tokenBlacklistService;
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
@@ -106,7 +104,8 @@ public class AuthService {
         String resolvedToken = extractToken(authorizationHeader);
         long expirationMillis = jwtProvider.getExpirationMillis(resolvedToken);
 
-        Member memberToWithdraw = memberService.findMemberById(authMember.id());
+        Member memberToWithdraw = memberRepository.findById(authMember.id())
+                .orElseThrow(() -> new GlobalException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         memberToWithdraw.withdraw();
         expireFcmToken(memberToWithdraw.getId(), withdrawRequest.fcmToken());

--- a/src/main/java/com/sparta/couponpop/domain/member/entity/Member.java
+++ b/src/main/java/com/sparta/couponpop/domain/member/entity/Member.java
@@ -86,4 +86,8 @@ public class Member extends BaseEntity {
     private void updatePassword(String encodedPassword) {
         this.password = encodedPassword;
     }
+
+    public void withdraw() {
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/sparta/couponpop/domain/member/service/MemberService.java
+++ b/src/main/java/com/sparta/couponpop/domain/member/service/MemberService.java
@@ -69,7 +69,7 @@ public class MemberService {
         }
     }
 
-    private Member findMemberById(Long memberId) {
+    public Member findMemberById(Long memberId) {
 
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new GlobalException(MemberErrorCode.MEMBER_NOT_FOUND));

--- a/src/main/java/com/sparta/couponpop/domain/member/service/MemberService.java
+++ b/src/main/java/com/sparta/couponpop/domain/member/service/MemberService.java
@@ -69,7 +69,7 @@ public class MemberService {
         }
     }
 
-    public Member findMemberById(Long memberId) {
+    private Member findMemberById(Long memberId) {
 
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new GlobalException(MemberErrorCode.MEMBER_NOT_FOUND));

--- a/src/test/java/com/sparta/couponpop/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/auth/controller/AuthControllerTest.java
@@ -7,6 +7,7 @@ import com.sparta.couponpop.common.security.dto.AuthMember;
 import com.sparta.couponpop.domain.auth.dto.request.LoginRequest;
 import com.sparta.couponpop.domain.auth.dto.request.LogoutRequest;
 import com.sparta.couponpop.domain.auth.dto.request.SignUpRequest;
+import com.sparta.couponpop.domain.auth.dto.request.WithdrawRequest;
 import com.sparta.couponpop.domain.auth.dto.response.LoginResponse;
 import com.sparta.couponpop.domain.auth.dto.response.SignUpResponse;
 import com.sparta.couponpop.domain.auth.service.AuthService;
@@ -27,6 +28,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -237,6 +239,31 @@ class AuthControllerTest {
         // when
         ResultActions resultActions = mockMvc.perform(
                 post("/api/v1/auth/logout") // 요청 URL
+                        .header("Authorization", testAuthorizationHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto))
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isNoContent())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴를 한다.")
+    @WithMockUser
+    void withdrawSuccess() throws Exception {
+
+        // given
+        String testAuthorizationHeader = "Bearer testToken";
+        WithdrawRequest requestDto = new WithdrawRequest("testFcmToken");
+
+        doNothing().when(authService).withdraw(anyString(), any(AuthMember.class), any(WithdrawRequest.class));
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                delete("/api/v1/auth/withdraw")
                         .header("Authorization", testAuthorizationHeader)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(requestDto))

--- a/src/test/java/com/sparta/couponpop/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/auth/service/AuthServiceTest.java
@@ -6,8 +6,10 @@ import com.sparta.couponpop.common.security.dto.AuthMember;
 import com.sparta.couponpop.domain.auth.dto.request.LoginRequest;
 import com.sparta.couponpop.domain.auth.dto.request.LogoutRequest;
 import com.sparta.couponpop.domain.auth.dto.request.SignUpRequest;
+import com.sparta.couponpop.domain.auth.dto.request.WithdrawRequest;
 import com.sparta.couponpop.domain.auth.dto.response.LoginResponse;
 import com.sparta.couponpop.domain.auth.dto.response.SignUpResponse;
+import com.sparta.couponpop.domain.auth.event.TokenBlacklistEvent;
 import com.sparta.couponpop.domain.auth.exception.AuthErrorCode;
 import com.sparta.couponpop.domain.member.entity.Member;
 import com.sparta.couponpop.domain.member.entity.MemberFcmToken;
@@ -15,16 +17,20 @@ import com.sparta.couponpop.domain.member.enums.MemberType;
 import com.sparta.couponpop.domain.member.exception.MemberErrorCode;
 import com.sparta.couponpop.domain.member.repository.MemberFcmTokenRepository;
 import com.sparta.couponpop.domain.member.repository.MemberRepository;
+import com.sparta.couponpop.domain.member.service.MemberService;
 import com.sparta.couponpop.utils.TestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Optional;
 
@@ -53,214 +59,316 @@ class AuthServiceTest {
     @Mock
     private TokenBlacklistService tokenBlacklistService;
 
+    @Mock
+    private MemberService memberService;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
     @InjectMocks
     private AuthService authService;
 
     private AuthMember testAuthMember;
-    private LogoutRequest testLogoutRequest;
     private String testAuthorizationHeader;
+    private LogoutRequest testLogoutRequest;
     private String testToken;
     private long testExpirationMillis;
 
     @BeforeEach
     void setUp() {
         testAuthMember = AuthMember.from(1L, "테스트이름", MemberType.CUSTOMER);
-        testLogoutRequest = new LogoutRequest("testFcmToken");
         testAuthorizationHeader = "Bearer " + "testAccessToken";
+        testLogoutRequest = new LogoutRequest("testFcmToken");
         testToken = "testAccessToken";
         testExpirationMillis = System.currentTimeMillis() + 3600000;
     }
 
-    @Test
-    @DisplayName("회원가입 정보를 받아 멤버를 생성한다.")
-    void signUpSuccess() {
+    @Nested
+    @DisplayName("회원 가입")
+    class SignUpTests {
 
-        // given
-        SignUpRequest signUpRequest = SignUpRequest.builder()
-                .email("test@example.com")
-                .username("테스트이름")
-                .password("test1234!")
-                .confirmPassword("test1234!")
-                .phoneNumber("01012345678")
-                .memberType(MemberType.CUSTOMER)
-                .build();
+        @Test
+        @DisplayName("회원가입 정보를 받아 멤버를 생성한다.")
+        void signUpSuccess() {
+
+            // given
+            SignUpRequest signUpRequest = SignUpRequest.builder()
+                    .email("test@example.com")
+                    .username("테스트이름")
+                    .password("test1234!")
+                    .confirmPassword("test1234!")
+                    .phoneNumber("01012345678")
+                    .memberType(MemberType.CUSTOMER)
+                    .build();
 
 
-        Member createdMember = Member.signUp("test@example.com",
-                "테스트이름",
-                "encodedPassword",
-                "01012345678",
-                MemberType.CUSTOMER
-        );
+            Member createdMember = Member.signUp("test@example.com",
+                    "테스트이름",
+                    "encodedPassword",
+                    "01012345678",
+                    MemberType.CUSTOMER
+            );
 
-        given(memberRepository.saveAndFlush(any(Member.class))).willReturn(createdMember);
+            given(memberRepository.saveAndFlush(any(Member.class))).willReturn(createdMember);
 
-        // when
-        SignUpResponse response = authService.signUp(signUpRequest);
+            // when
+            SignUpResponse response = authService.signUp(signUpRequest);
 
-        // then
-        assertThat(response).isNotNull();
-        assertThat(response.email()).isEqualTo(signUpRequest.email());
-        assertThat(response.username()).isEqualTo(signUpRequest.username());
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.email()).isEqualTo(signUpRequest.email());
+            assertThat(response.username()).isEqualTo(signUpRequest.username());
+        }
+
+        @Test
+        @DisplayName("비밀번호와 비밀번호 확인이 다르면 비밀번호 불일치 예외가 발생한다.")
+        void signUpFailurePasswordsNotMatch() {
+
+            // given
+            SignUpRequest request = SignUpRequest.builder()
+                    .email("test@example.com")
+                    .username("테스트이름")
+                    .password("test1234!")
+                    .confirmPassword("test1234@")
+                    .phoneNumber("01012345678")
+                    .memberType(MemberType.CUSTOMER)
+                    .build();
+
+            // when & then
+            GlobalException exception = assertThrows(GlobalException.class, () -> {
+                authService.signUp(request);
+            });
+
+            assertThat(exception.getErrorCode()).isEqualTo(AuthErrorCode.PASSWORDS_NOT_MATCH);
+        }
     }
 
-    @Test
-    @DisplayName("비밀번호와 비밀번호 확인이 다르면 비밀번호 불일치 예외가 발생한다.")
-    void signUpFailurePasswordsNotMatch() {
+    @Nested
+    @DisplayName("로그인")
+    class LoginTests {
 
-        // given
-        SignUpRequest request = SignUpRequest.builder()
-                .email("test@example.com")
-                .username("테스트이름")
-                .password("test1234!")
-                .confirmPassword("test1234@")
-                .phoneNumber("01012345678")
-                .memberType(MemberType.CUSTOMER)
-                .build();
+        @Test
+        @DisplayName("로그인 정보를 받아 토큰 반환에 성공한다.")
+        void loginSuccess() {
 
-        // when & then
-        GlobalException exception = assertThrows(GlobalException.class, () -> {
-            authService.signUp(request);
-        });
+            // given
+            LoginRequest loginRequest = new LoginRequest("test@example.com", "test1234!");
 
-        assertThat(exception.getErrorCode()).isEqualTo(AuthErrorCode.PASSWORDS_NOT_MATCH);
+            Member findMember = Member.signUp(
+                    "test@example.com",
+                    "테스트이름",
+                    "encodedPassword",
+                    "01012345678",
+                    MemberType.CUSTOMER
+            );
+
+            String expectedToken = "mockedJwtToken";
+
+            // Mock 객체의 행동을 정의합니다.
+            given(memberRepository.findByEmail(loginRequest.email())).willReturn(Optional.of(findMember));
+            given(passwordEncoder.matches(loginRequest.password(), findMember.getPassword())).willReturn(true);
+            given(jwtProvider.createAccessToken(findMember.getId(), findMember.getUsername(), findMember.getMemberType())).willReturn(expectedToken);
+
+            // when
+            LoginResponse response = authService.login(loginRequest);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.accessToken()).isEqualTo(expectedToken);
+        }
+
+        @Test
+        @DisplayName("로그인 요청의 이메일을 가진 멤버가 존재하지 않으면 예외가 발생한다.")
+        void loginFailureUserNotFound() {
+
+            // given
+            LoginRequest loginRequest = new LoginRequest("test@example.com", "test1234!");
+
+            given(memberRepository.findByEmail(anyString())).willReturn(Optional.empty());
+
+            // when & then
+            GlobalException exception = assertThrows(GlobalException.class, () -> {
+                authService.login(loginRequest);
+            });
+
+            assertThat(exception.getErrorCode()).isEqualTo(AuthErrorCode.INVALID_CREDENTIALS);
+            verify(passwordEncoder, never()).matches(anyString(), anyString());
+            verify(jwtProvider, never()).createAccessToken(any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("로그인 요청의 비밀번호와 저장된 비밀번호가 일치하지 않으면 예외가 발생한다.")
+        void loginFailurePasswordMismatch() {
+
+            // given
+            LoginRequest loginRequest = new LoginRequest("test@example.com", "test1234@");
+            Member findMember = Member.signUp(
+                    "test@example.com",
+                    "테스트이름",
+                    "encodedPassword",
+                    "01012345678",
+                    MemberType.CUSTOMER
+            );
+
+            given(memberRepository.findByEmail(loginRequest.email())).willReturn(Optional.of(findMember));
+            given(passwordEncoder.matches(loginRequest.password(), findMember.getPassword())).willReturn(false);
+
+            // when & then
+            GlobalException exception = assertThrows(GlobalException.class, () -> {
+                authService.login(loginRequest);
+            });
+
+            assertThat(exception.getErrorCode()).isEqualTo(AuthErrorCode.INVALID_CREDENTIALS);
+            verify(jwtProvider, never()).createAccessToken(any(), any(), any());
+        }
     }
 
-    @Test
-    @DisplayName("로그인 정보를 받아 토큰 반환에 성공한다.")
-    void loginSuccess() {
+    @Nested
+    @DisplayName("로그아웃")
+    class LogoutTests {
 
-        // given
-        LoginRequest loginRequest = new LoginRequest("test@example.com", "test1234!");
+        @Test
+        @DisplayName("로그아웃 정보를 받아 로그아웃에 성공한다.")
+        void logoutSuccess() {
 
-        Member findMember = Member.signUp(
-                "test@example.com",
-                "테스트이름",
-                "encodedPassword",
-                "01012345678",
-                MemberType.CUSTOMER
-        );
+            // given
+            MemberFcmToken mockFcmToken = TestUtils.createEntity(MemberFcmToken.class, Map.of("fcmToken", "testFcmToken"));
 
-        String expectedToken = "mockedJwtToken";
+            given(jwtProvider.resolveToken(testAuthorizationHeader)).willReturn(testToken);
+            given(jwtProvider.getExpirationMillis(testToken)).willReturn(testExpirationMillis);
 
-        // Mock 객체의 행동을 정의합니다.
-        given(memberRepository.findByEmail(loginRequest.email())).willReturn(Optional.of(findMember));
-        given(passwordEncoder.matches(loginRequest.password(), findMember.getPassword())).willReturn(true);
-        given(jwtProvider.createAccessToken(findMember.getId(), findMember.getUsername(), findMember.getMemberType())).willReturn(expectedToken);
+            given(memberFcmTokenRepository.findByMemberIdAndFcmToken(testAuthMember.id(), testLogoutRequest.fcmToken()))
+                    .willReturn(Optional.of(mockFcmToken));
 
-        // when
-        LoginResponse response = authService.login(loginRequest);
-
-        // then
-        assertThat(response).isNotNull();
-        assertThat(response.accessToken()).isEqualTo(expectedToken);
-    }
-
-    @Test
-    @DisplayName("로그인 요청의 이메일을 가진 멤버가 존재하지 않으면 예외가 발생한다.")
-    void loginFailureUserNotFound() {
-
-        // given
-        LoginRequest loginRequest = new LoginRequest("test@example.com", "test1234!");
-
-        given(memberRepository.findByEmail(anyString())).willReturn(Optional.empty());
-
-        // when & then
-        GlobalException exception = assertThrows(GlobalException.class, () -> {
-            authService.login(loginRequest);
-        });
-
-        assertThat(exception.getErrorCode()).isEqualTo(AuthErrorCode.INVALID_CREDENTIALS);
-        verify(passwordEncoder, never()).matches(anyString(), anyString());
-        verify(jwtProvider, never()).createAccessToken(any(), any(), any());
-    }
-
-    @Test
-    @DisplayName("로그인 요청의 비밀번호와 저장된 비밀번호가 일치하지 않으면 예외가 발생한다.")
-    void login_Failure_PasswordMismatch() {
-
-        // given
-        LoginRequest loginRequest = new LoginRequest("test@example.com", "test1234@");
-        Member findMember = Member.signUp(
-                "test@example.com",
-                "테스트이름",
-                "encodedPassword",
-                "01012345678",
-                MemberType.CUSTOMER
-        );
-
-        given(memberRepository.findByEmail(loginRequest.email())).willReturn(Optional.of(findMember));
-        given(passwordEncoder.matches(loginRequest.password(), findMember.getPassword())).willReturn(false);
-
-        // when & then
-        GlobalException exception = assertThrows(GlobalException.class, () -> {
-            authService.login(loginRequest);
-        });
-
-        assertThat(exception.getErrorCode()).isEqualTo(AuthErrorCode.INVALID_CREDENTIALS);
-        verify(jwtProvider, never()).createAccessToken(any(), any(), any());
-    }
-
-    @Test
-    @DisplayName("로그아웃 정보를 받아 로그아웃에 성공한다.")
-    void logoutSuccess() {
-
-        // given
-        MemberFcmToken mockFcmToken = TestUtils.createEntity(MemberFcmToken.class, Map.of("fcmToken", "testFcmToken"));// 임시 객체
-
-        given(jwtProvider.resolveToken(testAuthorizationHeader)).willReturn(testToken);
-        given(jwtProvider.getExpirationMillis(testToken)).willReturn(testExpirationMillis);
-
-        given(memberFcmTokenRepository.findByMemberIdAndFcmToken(testAuthMember.id(), testLogoutRequest.fcmToken()))
-                .willReturn(Optional.of(mockFcmToken));
-
-        // when
-        authService.logout(testAuthorizationHeader, testLogoutRequest, testAuthMember);
-
-        // then
-        // 1. expireToken() 검증
-        verify(jwtProvider).resolveToken(testAuthorizationHeader);
-        verify(jwtProvider).getExpirationMillis(testToken);
-        verify(tokenBlacklistService).blacklistToken(testToken, testExpirationMillis);
-
-        // 2. expireFcmToken() 검증
-        verify(memberFcmTokenRepository).findByMemberIdAndFcmToken(testAuthMember.id(), testLogoutRequest.fcmToken());
-        verify(memberFcmTokenRepository).delete(mockFcmToken);
-    }
-
-    @Test
-    @DisplayName("토큰이 존재하지 않으면, 로그아웃에 실패한다.")
-    void logoutFailureInvalidTokenHeader() {
-
-        // given
-        given(jwtProvider.resolveToken(testAuthorizationHeader)).willReturn(null);
-
-        // when & then
-        GlobalException exception = assertThrows(GlobalException.class, () -> {
+            // when
             authService.logout(testAuthorizationHeader, testLogoutRequest, testAuthMember);
-        });
 
-        assertThat(exception.getErrorCode()).isEqualTo(AuthErrorCode.INVALID_TOKEN);
-        verify(memberFcmTokenRepository, never()).findByMemberIdAndFcmToken(anyLong(), anyString());
+            // then
+            // 1. JWT 검증
+            verify(jwtProvider).resolveToken(testAuthorizationHeader);
+            verify(jwtProvider).getExpirationMillis(testToken);
+            verify(tokenBlacklistService).blacklistToken(testToken, testExpirationMillis);
+
+            // 2. FCM Token 검증
+            verify(memberFcmTokenRepository).findByMemberIdAndFcmToken(testAuthMember.id(), testLogoutRequest.fcmToken());
+            verify(memberFcmTokenRepository).delete(mockFcmToken);
+        }
+
+        @Test
+        @DisplayName("토큰이 존재하지 않으면, 로그아웃에 실패한다.")
+        void logoutFailureInvalidTokenHeader() {
+
+            // given
+            testLogoutRequest = new LogoutRequest("testFcmToken");
+
+            given(jwtProvider.resolveToken(testAuthorizationHeader)).willReturn(null);
+
+            // when & then
+            GlobalException exception = assertThrows(GlobalException.class, () -> {
+                authService.logout(testAuthorizationHeader, testLogoutRequest, testAuthMember);
+            });
+
+            assertThat(exception.getErrorCode()).isEqualTo(AuthErrorCode.INVALID_TOKEN);
+            verify(memberFcmTokenRepository, never()).findByMemberIdAndFcmToken(anyLong(), anyString());
+        }
+
+        @Test
+        @DisplayName("로그아웃 시 FCM 토큰이 없어도 로그아웃에 성공한다.")
+        void logoutSuccessWithoutFcmToken() {
+
+            // given
+            testLogoutRequest = new LogoutRequest("testFcmToken");
+            MemberFcmToken mockFcmToken = TestUtils.createEntity(MemberFcmToken.class, Map.of("fcmToken", "testFcmToken"));
+
+            given(jwtProvider.resolveToken(testAuthorizationHeader)).willReturn(testToken);
+            given(jwtProvider.getExpirationMillis(testToken)).willReturn(testExpirationMillis);
+
+            given(memberFcmTokenRepository.findByMemberIdAndFcmToken(testAuthMember.id(), testLogoutRequest.fcmToken()))
+                    .willReturn(Optional.empty());
+
+            // when
+            authService.logout(testAuthorizationHeader, testLogoutRequest, testAuthMember);
+
+            // then
+            // 1. JWT 검증
+            verify(jwtProvider).resolveToken(testAuthorizationHeader);
+            verify(jwtProvider).getExpirationMillis(testToken);
+            verify(tokenBlacklistService).blacklistToken(testToken, testExpirationMillis);
+
+            // 2. FCM Token 검증
+            verify(memberFcmTokenRepository).findByMemberIdAndFcmToken(testAuthMember.id(), testLogoutRequest.fcmToken());
+        }
     }
 
-    @Test
-    @DisplayName("FCM 토큰이 존재하지 않으면, 예외를 발생한다.")
-    void logout_Failure_FcmTokenNotFound() {
+    @Nested
+    @DisplayName("회원 탈퇴")
+    class WithdrawTests {
 
-        // given
-        given(jwtProvider.resolveToken(testAuthorizationHeader)).willReturn(testToken);
-        given(jwtProvider.getExpirationMillis(testToken)).willReturn(testExpirationMillis);
+        @Test
+        @DisplayName("회원 탈퇴 정보를 받아 회원 탈퇴에 성공한다.")
+        void withdrawSuccess() {
 
-        given(memberFcmTokenRepository.findByMemberIdAndFcmToken(testAuthMember.id(), testLogoutRequest.fcmToken()))
-                .willReturn(Optional.empty());
+            // given
+            Member mockMember = TestUtils.createEntity(Member.class, Map.of(
+                    "id", 1L,
+                    "username", "테스트이름",
+                    "email", "test@example.com",
+                    "password", "encodedPassword",
+                    "phoneNumber", "01012345678",
+                    "memberType", MemberType.CUSTOMER
+            ));
 
-        // when & then
-        GlobalException exception = assertThrows(GlobalException.class, () -> {
-            authService.logout(testAuthorizationHeader, testLogoutRequest, testAuthMember);
-        });
+            WithdrawRequest testWithdrawRequest = new WithdrawRequest("testFcmToken");
+            MemberFcmToken mockFcmToken = TestUtils.createEntity(MemberFcmToken.class, Map.of("fcmToken", "testFcmToken"));
 
-        assertThat(exception.getErrorCode()).isEqualTo(MemberErrorCode.MEMBER_FCM_TOKEN_NOT_FOUND);
-        verify(memberFcmTokenRepository, never()).delete(any(MemberFcmToken.class));
+            // member 조회
+            given(memberService.findMemberById(testAuthMember.id())).willReturn(mockMember);
+
+            // JWT
+            given(jwtProvider.resolveToken(testAuthorizationHeader)).willReturn(testToken);
+            given(jwtProvider.getExpirationMillis(testToken)).willReturn(testExpirationMillis);
+
+            // FCM 토큰
+            given(memberFcmTokenRepository.findByMemberIdAndFcmToken(testAuthMember.id(), testWithdrawRequest.fcmToken()))
+                    .willReturn(Optional.of(mockFcmToken));
+
+            // when
+            authService.withdraw(testAuthorizationHeader, testAuthMember, testWithdrawRequest);
+
+            // then
+            // soft delete 이므로 멤버 상태 변경 검증
+            assertThat(mockMember.getDeletedAt()).isNotNull()
+                    .isBeforeOrEqualTo(LocalDateTime.now());
+
+            // FCM 토큰
+            verify(memberFcmTokenRepository).findByMemberIdAndFcmToken(testAuthMember.id(), testWithdrawRequest.fcmToken());
+            verify(memberFcmTokenRepository).delete(mockFcmToken);
+
+            // JWT
+            verify(eventPublisher).publishEvent(any(TokenBlacklistEvent.class));
+        }
+
+        @Test
+        @DisplayName("회원 탈퇴 시 멤버를 찾지 못하면 예외가 발생한다.")
+        void withdrawFailureMemberNotFound() {
+
+            // given
+            WithdrawRequest testWithdrawRequest = new WithdrawRequest("testFcmToken");
+            given(memberService.findMemberById(testAuthMember.id()))
+                    .willThrow(new GlobalException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+            // JWT
+            given(jwtProvider.resolveToken(testAuthorizationHeader)).willReturn(testToken);
+            given(jwtProvider.getExpirationMillis(testToken)).willReturn(testExpirationMillis);
+
+            // when & then
+            GlobalException exception = assertThrows(GlobalException.class,
+                    () -> authService.withdraw("Bearer " + testToken, testAuthMember, testWithdrawRequest));
+
+            assertThat(exception.getErrorCode()).isEqualTo(MemberErrorCode.MEMBER_NOT_FOUND);
+
+            verify(memberFcmTokenRepository, never()).delete(any());
+            verify(eventPublisher, never()).publishEvent(any());
+        }
     }
 }

--- a/src/test/java/com/sparta/couponpop/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/auth/service/AuthServiceTest.java
@@ -322,7 +322,7 @@ class AuthServiceTest {
             MemberFcmToken mockFcmToken = TestUtils.createEntity(MemberFcmToken.class, Map.of("fcmToken", "testFcmToken"));
 
             // member 조회
-            given(memberService.findMemberById(testAuthMember.id())).willReturn(mockMember);
+            given(memberRepository.findById(testAuthMember.id())).willReturn(Optional.of(mockMember));
 
             // JWT
             given(jwtProvider.resolveToken(testAuthorizationHeader)).willReturn(testToken);
@@ -354,7 +354,7 @@ class AuthServiceTest {
 
             // given
             WithdrawRequest testWithdrawRequest = new WithdrawRequest("testFcmToken");
-            given(memberService.findMemberById(testAuthMember.id()))
+            given(memberRepository.findById(testAuthMember.id()))
                     .willThrow(new GlobalException(MemberErrorCode.MEMBER_NOT_FOUND));
 
             // JWT


### PR DESCRIPTION
## 🔗 **연관된 이슈**
> close #이슈번호

<br>

- close #13 

## 📝 **작업 내용**

- 회원 탈퇴 soft delete 로직 구현
- 엔드포인트 구현
- JWT, FCM token 만료 로직 구현
  - 이벤트리스너를 통해 회원 탈퇴가 이뤄져야 JWT 삭제가 이뤄지도록 구현
  - 로그아웃의 경우 의논한대로, JWT와 FCM은 원자성 보장 X
- 테스트 코드 작성
