### PR TITLE
feat : 손님 쿠폰 목록 조회 API

### DIFF
--- a/src/main/java/com/sparta/couponpop/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/sparta/couponpop/domain/coupon/controller/CouponController.java
@@ -4,11 +4,15 @@ import com.sparta.couponpop.common.response.ApiResponse;
 import com.sparta.couponpop.common.security.annotation.CurrentMember;
 import com.sparta.couponpop.common.security.dto.AuthMember;
 import com.sparta.couponpop.domain.coupon.dto.request.CouponIssueRequest;
+import com.sparta.couponpop.domain.coupon.dto.request.MemberIssuedCouponCursor;
 import com.sparta.couponpop.domain.coupon.dto.request.UseCouponRequest;
 import com.sparta.couponpop.domain.coupon.dto.response.CouponDetailResponse;
+import com.sparta.couponpop.domain.coupon.dto.response.IssuedCouponListResponse;
+import com.sparta.couponpop.domain.coupon.enums.CouponStatus;
 import com.sparta.couponpop.domain.coupon.service.CouponService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -39,5 +43,18 @@ public class CouponController {
         LocalDateTime usedAt = LocalDateTime.now();
         couponService.useCoupon(request.couponId(), request.qrCode(), authMember.id(), usedAt);
         return ApiResponse.noContent();
+    }
+
+    @GetMapping("/coupons")
+    public ResponseEntity<ApiResponse<IssuedCouponListResponse>> getIssuedCoupons(
+            @RequestParam CouponStatus type,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime lastEventEndAt,
+            @RequestParam(required = false) Long lastCouponId,
+            @RequestParam(defaultValue = "10") int size,
+            @CurrentMember AuthMember authMember
+    ) {
+        var cursor = MemberIssuedCouponCursor.ofNullable(lastEventEndAt, lastCouponId);
+        IssuedCouponListResponse response = couponService.getIssuedCoupons(authMember.id(), type, cursor, size);
+        return ApiResponse.success(response);
     }
 }

--- a/src/main/java/com/sparta/couponpop/domain/coupon/dto/request/MemberIssuedCouponCursor.java
+++ b/src/main/java/com/sparta/couponpop/domain/coupon/dto/request/MemberIssuedCouponCursor.java
@@ -1,0 +1,19 @@
+package com.sparta.couponpop.domain.coupon.dto.request;
+
+import java.time.LocalDateTime;
+
+public record MemberIssuedCouponCursor(
+        LocalDateTime lastEventEndAt,
+        Long lastCouponId
+) {
+    public static MemberIssuedCouponCursor first() {
+        return new MemberIssuedCouponCursor(null, null);
+    }
+
+    public static MemberIssuedCouponCursor ofNullable(LocalDateTime lastEventEndAt, Long lastCouponId) {
+        return (lastEventEndAt != null && lastCouponId != null) ?
+                new MemberIssuedCouponCursor(lastEventEndAt, lastCouponId) :
+                MemberIssuedCouponCursor.first();
+    }
+
+}

--- a/src/main/java/com/sparta/couponpop/domain/coupon/dto/response/IssuedCouponListResponse.java
+++ b/src/main/java/com/sparta/couponpop/domain/coupon/dto/response/IssuedCouponListResponse.java
@@ -1,0 +1,49 @@
+package com.sparta.couponpop.domain.coupon.dto.response;
+
+import com.sparta.couponpop.domain.coupon.dto.request.MemberIssuedCouponCursor;
+import com.sparta.couponpop.domain.coupon.repository.dto.CouponSummaryInfoProjection;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public record IssuedCouponListResponse(
+        List<CouponSummaryInfoProjection> coupons,
+        MemberIssuedCouponCursor nextCursor,
+        int size,
+        boolean hasNext
+) {
+    public static IssuedCouponListResponse of(List<CouponSummaryInfoProjection> originalCoupons, int pageSize) {
+        if (originalCoupons == null || originalCoupons.isEmpty()) {
+            return new IssuedCouponListResponse(List.of(), null, 0, false);
+        }
+
+        boolean hasNext = originalCoupons.size() > pageSize;
+        List<CouponSummaryInfoProjection> coupons = trimToPageSize(originalCoupons, pageSize);
+        MemberIssuedCouponCursor nextCursor = hasNext ? buildNextCursor(coupons) : null;
+
+        return new IssuedCouponListResponse(List.copyOf(coupons), nextCursor, coupons.size(), hasNext);
+    }
+
+    private static List<CouponSummaryInfoProjection> trimToPageSize(List<CouponSummaryInfoProjection> coupons, int pageSize) {
+        if (coupons.size() <= pageSize) {
+            return coupons;
+        }
+        // 원본 리스트 변형 방지를 위해 복사 후 제거
+        List<CouponSummaryInfoProjection> trimmed = new ArrayList<>(coupons);
+        trimmed.remove(trimmed.size() - 1);
+        return trimmed;
+    }
+
+    private static MemberIssuedCouponCursor buildNextCursor(List<CouponSummaryInfoProjection> coupons) {
+        if (coupons.isEmpty()) {
+            return null;
+        }
+
+        CouponSummaryInfoProjection lastCoupon = coupons.get(coupons.size() - 1);
+        return new MemberIssuedCouponCursor(
+                lastCoupon.event().period().end(),
+                lastCoupon.id()
+        );
+    }
+
+}

--- a/src/main/java/com/sparta/couponpop/domain/coupon/repository/CouponQueryRepository.java
+++ b/src/main/java/com/sparta/couponpop/domain/coupon/repository/CouponQueryRepository.java
@@ -1,0 +1,12 @@
+package com.sparta.couponpop.domain.coupon.repository;
+
+import com.sparta.couponpop.domain.coupon.enums.CouponStatus;
+import com.sparta.couponpop.domain.coupon.repository.dto.CouponSummaryInfoProjection;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface CouponQueryRepository {
+
+    List<CouponSummaryInfoProjection> findAllByMemberIdWithEventAndStore(Long memberId, CouponStatus status, LocalDateTime lastEventEndAt, Long lastCouponId, int limit);
+}

--- a/src/main/java/com/sparta/couponpop/domain/coupon/repository/CouponQueryRepositoryImpl.java
+++ b/src/main/java/com/sparta/couponpop/domain/coupon/repository/CouponQueryRepositoryImpl.java
@@ -1,0 +1,92 @@
+package com.sparta.couponpop.domain.coupon.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.couponpop.domain.coupon.entity.QCoupon;
+import com.sparta.couponpop.domain.coupon.enums.CouponStatus;
+import com.sparta.couponpop.domain.coupon.repository.dto.CouponSummaryInfoProjection;
+import com.sparta.couponpop.domain.coupon.repository.dto.QCouponSummaryInfoProjection;
+import com.sparta.couponpop.domain.couponevent.entity.QCouponEvent;
+import com.sparta.couponpop.domain.store.entity.QStore;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public class CouponQueryRepositoryImpl implements CouponQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<CouponSummaryInfoProjection> findAllByMemberIdWithEventAndStore(Long memberId, CouponStatus status, LocalDateTime lastEventEndAt, Long lastCouponId, int limit) {
+        QCoupon coupon = QCoupon.coupon;
+        QCouponEvent couponEvent = QCouponEvent.couponEvent;
+        QStore store = QStore.store;
+
+        // TODO 정렬 조건은 couponEvent end가 아닌 쿠폰 만료 시간으로 할것!!
+        return jpaQueryFactory
+                .select(
+                        new QCouponSummaryInfoProjection(
+                                coupon.id,
+                                coupon.couponStatus,
+                                coupon.receivedAt,
+                                coupon.expireAt,
+                                coupon.usedAt,
+                                couponEvent.id,
+                                couponEvent.name,
+                                couponEvent.eventStartAt,
+                                couponEvent.eventEndAt,
+                                store.id,
+                                store.name,
+                                store.storeCategory,
+                                store.latitude,
+                                store.longitude,
+                                store.imageUrl
+                        )
+                )
+                .from(coupon)
+                .leftJoin(coupon.couponEvent, couponEvent)
+                .leftJoin(couponEvent.store, store)
+                .where(
+                        coupon.member.id.eq(memberId),
+                        coupon.couponStatus.eq(status),
+                        nextCouponCursorCondition(coupon, lastEventEndAt, lastCouponId)
+                )
+                .orderBy(
+                        coupon.couponEvent.eventEndAt.asc(),
+                        coupon.id.asc()
+                )
+                .limit(limit)
+                .fetch();
+    }
+
+    /**
+     * Cursor 기반 다음 페이지 조회 조건
+     *
+     * <p>조건:</p>
+     * <ol>
+     *     <li>eventEndAt > lastEventEndAt → 다음 페이지</li>
+     *     <li>eventEndAt = lastEventEndAt 이면 couponId > lastCouponId → 다음 페이지</li>
+     * </ol>
+     *
+     * @param coupon         QCoupon 객체
+     * @param lastEventEndAt 이전 페이지 마지막 쿠폰 이벤트 종료 시간
+     * @param lastCouponId   이전 페이지 마지막 쿠폰 ID
+     * @return BooleanExpression (QueryDSL where 조건)
+     */
+    private BooleanExpression nextCouponCursorCondition(QCoupon coupon, LocalDateTime lastEventEndAt, Long lastCouponId) {
+        if (lastEventEndAt == null || lastCouponId == null) {
+            return null; // 첫 페이지 조회
+        }
+
+        return coupon.couponEvent.eventEndAt.gt(lastEventEndAt)
+                .or(
+                        coupon.couponEvent.eventEndAt.eq(lastEventEndAt)
+                                .and(coupon.id.gt(lastCouponId))
+                );
+    }
+
+}

--- a/src/main/java/com/sparta/couponpop/domain/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/sparta/couponpop/domain/coupon/repository/CouponRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
-public interface CouponRepository extends JpaRepository<Coupon, Long> {
+public interface CouponRepository extends JpaRepository<Coupon, Long>, CouponQueryRepository {
 
     @Query("""
             select count(c)
@@ -38,4 +38,5 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
             where c.id = :couponId
             """)
     Optional<Coupon> findByIdWithCouponEventForUpdate(@Param("couponId") Long couponId);
+
 }

--- a/src/main/java/com/sparta/couponpop/domain/coupon/repository/dto/CouponSummaryInfoProjection.java
+++ b/src/main/java/com/sparta/couponpop/domain/coupon/repository/dto/CouponSummaryInfoProjection.java
@@ -1,0 +1,61 @@
+package com.sparta.couponpop.domain.coupon.repository.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import com.sparta.couponpop.domain.coupon.enums.CouponStatus;
+import com.sparta.couponpop.domain.store.enums.StoreCategory;
+
+import java.time.LocalDateTime;
+
+public record CouponSummaryInfoProjection(
+        Long id,
+        CouponStatus status,
+        LocalDateTime issuedAt,
+        LocalDateTime expireAt,
+        LocalDateTime usedAt,
+        EventInfo event,
+        StoreInfo store
+) {
+
+    public record EventInfo(
+            Long id,
+            String name,
+            EventPeriod period
+    ) {
+        public record EventPeriod(LocalDateTime start, LocalDateTime end) {
+        }
+    }
+
+    public record StoreInfo(
+            Long id,
+            String name,
+            StoreCategory storeCategory,
+            double latitude,
+            double longitude,
+            String imageUrl
+    ) {
+    }
+
+    @QueryProjection
+    public CouponSummaryInfoProjection(
+            Long id,
+            CouponStatus status,
+            LocalDateTime issuedAt,
+            LocalDateTime expireAt,
+            LocalDateTime usedAt,
+            Long eventId,
+            String eventName,
+            LocalDateTime eventStartAt,
+            LocalDateTime eventEndAt,
+            Long storeId,
+            String storeName,
+            StoreCategory storeCategory,
+            double latitude,
+            double longitude,
+            String imageUrl
+    ) {
+        this(id, status, issuedAt, expireAt, usedAt,
+                new EventInfo(eventId, eventName, new EventInfo.EventPeriod(eventStartAt, eventEndAt)),
+                new StoreInfo(storeId, storeName, storeCategory, latitude, longitude, imageUrl)
+        );
+    }
+}

--- a/src/main/java/com/sparta/couponpop/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/sparta/couponpop/domain/coupon/service/CouponService.java
@@ -1,11 +1,15 @@
 package com.sparta.couponpop.domain.coupon.service;
 
 import com.sparta.couponpop.common.exception.GlobalException;
+import com.sparta.couponpop.domain.coupon.dto.request.MemberIssuedCouponCursor;
 import com.sparta.couponpop.domain.coupon.dto.response.CouponDetailResponse;
+import com.sparta.couponpop.domain.coupon.dto.response.IssuedCouponListResponse;
 import com.sparta.couponpop.domain.coupon.entity.Coupon;
+import com.sparta.couponpop.domain.coupon.enums.CouponStatus;
 import com.sparta.couponpop.domain.coupon.exception.CouponErrorCode;
 import com.sparta.couponpop.domain.coupon.repository.CouponRepository;
 import com.sparta.couponpop.domain.coupon.repository.TemporaryCouponCodeRepository;
+import com.sparta.couponpop.domain.coupon.repository.dto.CouponSummaryInfoProjection;
 import com.sparta.couponpop.domain.couponevent.entity.CouponEvent;
 import com.sparta.couponpop.domain.couponevent.exception.CouponEventErrorCode;
 import com.sparta.couponpop.domain.couponevent.repository.CouponEventRepository;
@@ -21,6 +25,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -158,6 +163,27 @@ public class CouponService {
 
         // Redis 임시 코드 삭제
         temporaryCouponCodeRepository.deleteTemporaryCoupon(couponId, qrCode);
+    }
+
+    /**
+     * 사용자가 발급받은 쿠폰 목록을 페이지네이션 방식으로 조회합니다.
+     *
+     * <p>조회 시 pageSize + 1개를 가져와서 다음 페이지 존재 여부(hasNext)를 판단합니다.</p>
+     *
+     * @param memberId 조회 대상 회원 ID
+     * @param status   조회할 쿠폰 상태
+     * @param cursor   이전 페이지 마지막 쿠폰 정보로, 다음 페이지 조회 기준이 됩니다.
+     *                 첫 페이지 조회 시 null 또는 MemberIssuedCouponCursor.first() 사용
+     * @param pageSize 한 페이지에 보여줄 최대 쿠폰 수
+     * @return 쿠폰 목록과 페이지 정보가 포함된 IssuedCouponListResponse
+     */
+    public IssuedCouponListResponse getIssuedCoupons(Long memberId, CouponStatus status, MemberIssuedCouponCursor cursor, int pageSize) {
+        // pageSize + 1 조회 (hasNext 확인용)
+        List<CouponSummaryInfoProjection> coupons = couponRepository.findAllByMemberIdWithEventAndStore(
+                memberId, status, cursor.lastEventEndAt(), cursor.lastCouponId(), pageSize + 1
+        );
+
+        return IssuedCouponListResponse.of(coupons, pageSize);
     }
 
     private CouponEvent validateEventBelongsToStore(Long eventId, Store store) {

--- a/src/test/java/com/sparta/couponpop/domain/coupon/controller/CouponControllerTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/coupon/controller/CouponControllerTest.java
@@ -7,13 +7,18 @@ import com.sparta.couponpop.common.security.JwtAuthenticationToken;
 import com.sparta.couponpop.common.security.JwtProvider;
 import com.sparta.couponpop.common.security.dto.AuthMember;
 import com.sparta.couponpop.domain.coupon.dto.request.CouponIssueRequest;
+import com.sparta.couponpop.domain.coupon.dto.request.MemberIssuedCouponCursor;
 import com.sparta.couponpop.domain.coupon.dto.request.UseCouponRequest;
 import com.sparta.couponpop.domain.coupon.dto.response.CouponDetailResponse;
+import com.sparta.couponpop.domain.coupon.dto.response.IssuedCouponListResponse;
 import com.sparta.couponpop.domain.coupon.enums.CouponStatus;
 import com.sparta.couponpop.domain.coupon.exception.CouponErrorCode;
+import com.sparta.couponpop.domain.coupon.repository.dto.CouponSummaryInfoProjection;
 import com.sparta.couponpop.domain.coupon.service.CouponService;
+import com.sparta.couponpop.domain.couponevent.entity.CouponEvent;
 import com.sparta.couponpop.domain.couponevent.exception.CouponEventErrorCode;
 import com.sparta.couponpop.domain.member.enums.MemberType;
+import com.sparta.couponpop.utils.TestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -30,6 +35,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
@@ -398,6 +405,72 @@ class CouponControllerTest {
                     .andDo(print())
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.error.message").value("사용하려는 쿠폰 ID는 필수입니다."));
+        }
+    }
+
+    @Nested
+    @DisplayName("쿠폰 리스트 조회")
+    class GetIssuedCoupons {
+
+        private static final LocalDateTime now = LocalDateTime.now();
+
+        @Test
+        @DisplayName("첫 페이지 조회 - hasNext true")
+        void getIssuedCoupons_firstPage_hasNextTrue() throws Exception {
+            // given
+            CouponSummaryInfoProjection.EventInfo event = new CouponSummaryInfoProjection.EventInfo(1L, "이벤트",
+                    new CouponSummaryInfoProjection.EventInfo.EventPeriod(
+                            now.minusDays(2),
+                            now.plusDays(1)
+                    ));
+            List<CouponSummaryInfoProjection> mockCoupons = List.of(
+                    new CouponSummaryInfoProjection(1L, CouponStatus.AVAILABLE, now.minusDays(1), now.plusDays(1), null, event, null),
+                    new CouponSummaryInfoProjection(2L, CouponStatus.AVAILABLE, now.minusDays(1), now.plusDays(1), null, event, null),
+                    new CouponSummaryInfoProjection(3L, CouponStatus.AVAILABLE, now.minusDays(1), now.plusDays(1), null, event, null)
+            );
+//
+            IssuedCouponListResponse mockResponse = IssuedCouponListResponse.of(mockCoupons, 2);
+
+            given(couponService.getIssuedCoupons(anyLong(), eq(CouponStatus.AVAILABLE), any(MemberIssuedCouponCursor.class), eq(2)))
+                    .willReturn(mockResponse);
+
+            // when & then
+            mockMvc.perform(
+                            get("/api/v1/coupons")
+                                    .param("type", "AVAILABLE")
+                                    .param("size", "2")
+                                    .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.coupons.length()").value(2))
+                    .andExpect(jsonPath("$.data.hasNext").value(true))
+                    .andExpect(jsonPath("$.data.nextCursor").isNotEmpty());
+        }
+
+        @Test
+        @DisplayName("다음 페이지 조회 - 마지막 페이지 (hasNext false)")
+        void getIssuedCoupons_nextPage_lastPage() throws Exception {
+            // given
+            List<CouponSummaryInfoProjection> mockCoupons = List.of(
+                    new CouponSummaryInfoProjection(3L, CouponStatus.AVAILABLE, now.minusDays(1), now.plusDays(1), null, null, null)
+            );
+
+            IssuedCouponListResponse mockResponse = IssuedCouponListResponse.of(mockCoupons, 2);
+
+            given(couponService.getIssuedCoupons(anyLong(), eq(CouponStatus.AVAILABLE), any(MemberIssuedCouponCursor.class), eq(2)))
+                    .willReturn(mockResponse);
+
+            // when & then
+            mockMvc.perform(
+                            get("/api/v1/coupons")
+                                    .param("type", "AVAILABLE")
+                                    .param("lastEventEndAt", now.minusDays(1).toString())
+                                    .param("lastCouponId", "2")
+                                    .param("size", "2")
+                                    .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.coupons.length()").value(1))
+                    .andExpect(jsonPath("$.data.hasNext").value(false))
+                    .andExpect(jsonPath("$.data.nextCursor").isEmpty());
         }
     }
 }

--- a/src/test/java/com/sparta/couponpop/domain/coupon/service/CouponServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/coupon/service/CouponServiceTest.java
@@ -1,12 +1,15 @@
 package com.sparta.couponpop.domain.coupon.service;
 
 import com.sparta.couponpop.common.exception.GlobalException;
+import com.sparta.couponpop.domain.coupon.dto.request.MemberIssuedCouponCursor;
 import com.sparta.couponpop.domain.coupon.dto.response.CouponDetailResponse;
+import com.sparta.couponpop.domain.coupon.dto.response.IssuedCouponListResponse;
 import com.sparta.couponpop.domain.coupon.entity.Coupon;
 import com.sparta.couponpop.domain.coupon.enums.CouponStatus;
 import com.sparta.couponpop.domain.coupon.exception.CouponErrorCode;
 import com.sparta.couponpop.domain.coupon.repository.CouponRepository;
 import com.sparta.couponpop.domain.coupon.repository.TemporaryCouponCodeRepository;
+import com.sparta.couponpop.domain.coupon.repository.dto.CouponSummaryInfoProjection;
 import com.sparta.couponpop.domain.couponevent.entity.CouponEvent;
 import com.sparta.couponpop.domain.couponevent.enums.CouponEventStatus;
 import com.sparta.couponpop.domain.couponevent.exception.CouponEventErrorCode;
@@ -27,6 +30,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -433,6 +437,120 @@ class CouponServiceTest {
             assertThatThrownBy(() -> couponService.useCoupon(coupon.getId(), "QR123", member.getId(), usedAt))
                     .isInstanceOf(GlobalException.class)
                     .hasMessage(CouponErrorCode.COUPON_NOT_AVAILABLE.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("쿠폰 리스트 조회 - 커서 기반")
+    class GetIssuedCoupons {
+        private static final LocalDateTime now = LocalDateTime.of(2025, 10, 20, 16, 0);
+
+        private CouponSummaryInfoProjection createMockCoupon(Long id, LocalDateTime eventEndAt) {
+            return new CouponSummaryInfoProjection(
+                    id,
+                    CouponStatus.AVAILABLE,
+                    now.minusDays(1),
+                    now.plusDays(5),
+                    null,
+                    id,
+                    "Event " + id,
+                    now.minusDays(2),
+                    eventEndAt,
+                    1L,
+                    "Store " + id,
+                    null,
+                    37.0,
+                    127.0,
+                    "image.png"
+            );
+        }
+
+        @Test
+        @DisplayName("첫 페이지 조회 - hasNext true")
+        void getIssuedCoupons_firstPage_hasNextTrue() {
+            // given
+            var cursor = MemberIssuedCouponCursor.first();
+            int pageSize = 2;
+
+            List<CouponSummaryInfoProjection> mockCoupons = List.of(
+                    createMockCoupon(1L, now.minusHours(1)),
+                    createMockCoupon(2L, now),
+                    createMockCoupon(3L, now.plusHours(1)) // pageSize + 1
+            );
+
+            given(couponRepository.findAllByMemberIdWithEventAndStore(anyLong(), any(CouponStatus.class), isNull(), isNull(), eq(pageSize + 1)))
+                    .willReturn(mockCoupons);
+
+            // when
+            IssuedCouponListResponse response = couponService.getIssuedCoupons(
+                    member.getId(), CouponStatus.AVAILABLE, cursor, pageSize
+            );
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.size()).isEqualTo(pageSize); // 리스트 trimming
+            assertThat(response.hasNext()).isTrue();
+            assertThat(response.nextCursor()).isNotNull();
+            assertThat(response.nextCursor().lastCouponId()).isEqualTo(2L);
+        }
+
+        @Test
+        @DisplayName("마지막 페이지 조회 - hasNext false")
+        void getIssuedCoupons_lastPage_hasNextFalse() {
+            // given
+            LocalDateTime lastEventEndAt = now.plusHours(1);
+            Long lastCouponId = 3L;
+            var cursor = new MemberIssuedCouponCursor(lastEventEndAt, lastCouponId);
+            int pageSize = 3;
+
+            List<CouponSummaryInfoProjection> mockCoupons = List.of(
+                    createMockCoupon(1L, now.minusHours(1)),
+                    createMockCoupon(2L, now),
+                    createMockCoupon(lastCouponId, lastEventEndAt)
+            );
+
+            given(couponRepository.findAllByMemberIdWithEventAndStore(anyLong(), any(CouponStatus.class), any(LocalDateTime.class), anyLong(), eq(pageSize + 1)))
+                    .willReturn(mockCoupons);
+
+            // when
+            IssuedCouponListResponse response = couponService.getIssuedCoupons(
+                    member.getId(), CouponStatus.AVAILABLE, cursor, pageSize
+            );
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.size()).isEqualTo(pageSize);
+            assertThat(response.hasNext()).isFalse();
+            assertThat(response.nextCursor()).isNull();
+        }
+
+        @Test
+        @DisplayName("커서 이후 조회")
+        void getIssuedCoupons_nextCursorPage() {
+            // given
+            var lastCursor = new MemberIssuedCouponCursor(now.minusHours(1), 1L);
+            int pageSize = 2;
+
+            List<CouponSummaryInfoProjection> mockCoupons = List.of(
+                    createMockCoupon(2L, now),
+                    createMockCoupon(3L, now.plusHours(1)),
+                    createMockCoupon(4L, now.plusHours(2))
+            );
+
+            given(couponRepository.findAllByMemberIdWithEventAndStore(anyLong(), any(CouponStatus.class), any(LocalDateTime.class), anyLong(), eq(pageSize + 1)))
+                    .willReturn(mockCoupons);
+
+            // when
+            IssuedCouponListResponse response = couponService.getIssuedCoupons(
+                    member.getId(), CouponStatus.AVAILABLE, lastCursor, pageSize
+            );
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.size()).isEqualTo(pageSize); // 리스트 trimming
+            assertThat(response.hasNext()).isTrue();
+            assertThat(response.nextCursor()).isNotNull();
+            assertThat(response.nextCursor().lastCouponId()).isEqualTo(3L);
         }
     }
 }


### PR DESCRIPTION
## 🔗 **연관된 이슈**

- close #40

<br>

## 📝 PR: 쿠폰 리스트 조회 (Cursor 기반)

---

### 1️⃣ Service 테스트 (쿠폰 리스트 조회)

| 테스트 | 설명 | 기대 결과 |
|--------|------|-----------|
| 첫 페이지 조회 | `pageSize + 1` 데이터 존재 | 리스트 trimming → `size == pageSize`, `hasNext == true`, `nextCursor` 존재 |
| 마지막 페이지 조회 | 더 이상 데이터 없음 | `size == pageSize`, `hasNext == false`, `nextCursor == null` |
| 커서 이후 조회 | cursor 기반 다음 페이지 | `size == pageSize`, `hasNext == true`, `nextCursor` 갱신 |

### 🔹 핵심 검증 포인트
- **커서 기반 페이지네이션** 정상 동작 확인  
  - `pageSize + 1` 조회 → 리스트 trimming + `hasNext` 계산  
  - `nextCursor` 생성 여부 확인  
- **쿠폰 데이터 상태 검증**  
  - 반환 리스트 요소 `CouponSummaryInfoProjection` 필드 값 확인 (ID, 상태, 이벤트 기간 등)  

### 🔹 비고
- Service 테스트는 **비즈니스 로직 단위 검증** 중심  
- Redis, DB, 동시성 로직은 **별도의 통합 테스트**에서 확인 가능  

---

### 2️⃣ Controller 테스트 (MockMvc)

| 테스트 | 요청 | 기대 결과 |
|--------|------|-----------|
| 첫 페이지 조회 | `GET /api/v1/coupons?type=AVAILABLE&size=2` | HTTP `200 OK`, `$.data.coupons.length() == 2`, `$.data.hasNext == true`, `$.data.nextCursor` 존재 |
| 다음 페이지 조회 | `GET /api/v1/coupons?type=AVAILABLE&lastEventEndAt=...&lastCouponId=...&size=2` | HTTP `200 OK`, `$.data.coupons.length() == 1`, `$.data.hasNext == false`, `$.data.nextCursor` null |

### 🔹 핵심 검증 포인트
- **HTTP 상태 코드 및 JSON 구조 검증**  
- 요청 파라미터(`type`, `lastEventEndAt`, `lastCouponId`, `size`)에 따른 정상 응답 확인  
- **Controller ↔ Service 호출 일관성 확인**  

### 🔹 비고
- Controller 테스트는 **HTTP 요청/응답과 JSON 직렬화** 검증 중심  
- 비즈니스 로직 단위 검증은 Service 테스트에서 수행  

## 📸 **스크린샷 (선택)**

<br>
