### PR TITLE
feat : 매장 별 이벤트 목록 조회 API

### DIFF
--- a/src/main/java/com/sparta/couponpop/domain/couponevent/controller/CouponEventController.java
+++ b/src/main/java/com/sparta/couponpop/domain/couponevent/controller/CouponEventController.java
@@ -6,11 +6,14 @@ import com.sparta.couponpop.common.security.dto.AuthMember;
 import com.sparta.couponpop.domain.couponevent.dto.request.CreateCouponEventRequest;
 import com.sparta.couponpop.domain.couponevent.dto.response.CouponEventDetailResponse;
 import com.sparta.couponpop.domain.couponevent.dto.response.CreateCouponEventResponse;
+import com.sparta.couponpop.domain.couponevent.dto.response.StoreCouponEventListResponse;
+import com.sparta.couponpop.domain.couponevent.enums.CouponEventStatus;
+import com.sparta.couponpop.domain.couponevent.repository.dto.StoreCouponEventsCursor;
 import com.sparta.couponpop.domain.couponevent.service.CouponEventService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
@@ -38,4 +41,22 @@ public class CouponEventController {
         CouponEventDetailResponse response = couponEventService.getCouponEvent(eventId, authMember.id(), now);
         return ApiResponse.success(response);
     }
+
+    // TODO : 나중에 Store 도메인으로 옮기는 거 고려하기
+    @GetMapping("/owner/stores/{storeId}/coupons/events")
+    public ResponseEntity<ApiResponse<StoreCouponEventListResponse>> getCouponEventsByStore(
+            @PathVariable Long storeId,
+            @RequestParam(defaultValue = "IN_PROGRESS", required = false) CouponEventStatus status,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime lastStartAt,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime lastEndAt,
+            @RequestParam(required = false) Long lastEventId,
+            @RequestParam(defaultValue = "10") int size,
+            @CurrentMember AuthMember authMember
+    ) {
+        StoreCouponEventsCursor cursor = StoreCouponEventsCursor.ofNullable(lastStartAt, lastEndAt, lastEventId);
+        StoreCouponEventListResponse response = couponEventService.getCouponEventsByStore(authMember.id(), storeId, status, cursor, size);
+        return ApiResponse.success(response);
+    }
+
+
 }

--- a/src/main/java/com/sparta/couponpop/domain/couponevent/controller/CouponEventController.java
+++ b/src/main/java/com/sparta/couponpop/domain/couponevent/controller/CouponEventController.java
@@ -8,7 +8,7 @@ import com.sparta.couponpop.domain.couponevent.dto.response.CouponEventDetailRes
 import com.sparta.couponpop.domain.couponevent.dto.response.CreateCouponEventResponse;
 import com.sparta.couponpop.domain.couponevent.dto.response.StoreCouponEventListResponse;
 import com.sparta.couponpop.domain.couponevent.enums.CouponEventStatus;
-import com.sparta.couponpop.domain.couponevent.repository.dto.StoreCouponEventsCursor;
+import com.sparta.couponpop.domain.couponevent.dto.cursor.StoreCouponEventsCursor;
 import com.sparta.couponpop.domain.couponevent.service.CouponEventService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/sparta/couponpop/domain/couponevent/dto/cursor/StoreCouponEventsCursor.java
+++ b/src/main/java/com/sparta/couponpop/domain/couponevent/dto/cursor/StoreCouponEventsCursor.java
@@ -1,4 +1,4 @@
-package com.sparta.couponpop.domain.couponevent.repository.dto;
+package com.sparta.couponpop.domain.couponevent.dto.cursor;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/sparta/couponpop/domain/couponevent/dto/response/CouponEventDetailResponse.java
+++ b/src/main/java/com/sparta/couponpop/domain/couponevent/dto/response/CouponEventDetailResponse.java
@@ -35,7 +35,7 @@ public record CouponEventDetailResponse(
                 eventWithUsedCount.eventStatus(),
                 EventStatisticSummary.of(eventWithUsedCount.totalCount(), eventWithUsedCount.issuedCount(), eventWithUsedCount.usedCouponCount()),
                 eventWithUsedCount.createdAt(),
-                eventWithUsedCount.updatedA()
+                eventWithUsedCount.updatedAt()
         );
     }
 }

--- a/src/main/java/com/sparta/couponpop/domain/couponevent/dto/response/CouponEventDetailResponse.java
+++ b/src/main/java/com/sparta/couponpop/domain/couponevent/dto/response/CouponEventDetailResponse.java
@@ -2,6 +2,7 @@ package com.sparta.couponpop.domain.couponevent.dto.response;
 
 import com.sparta.couponpop.domain.couponevent.entity.CouponEvent;
 import com.sparta.couponpop.domain.couponevent.enums.CouponEventStatus;
+import com.sparta.couponpop.domain.couponevent.repository.dto.CouponEventWithUsedCountProjection;
 
 import java.time.LocalDateTime;
 
@@ -23,6 +24,18 @@ public record CouponEventDetailResponse(
                 EventStatisticSummary.of(couponEvent, usedCouponCount),
                 couponEvent.getCreatedAt(),
                 couponEvent.getUpdatedAt()
+        );
+    }
+
+    public static CouponEventDetailResponse of(CouponEventWithUsedCountProjection eventWithUsedCount) {
+        return new CouponEventDetailResponse(
+                eventWithUsedCount.id(),
+                eventWithUsedCount.eventName(),
+                EventPeriod.of(eventWithUsedCount.start(), eventWithUsedCount.end()),
+                eventWithUsedCount.eventStatus(),
+                EventStatisticSummary.of(eventWithUsedCount.totalCount(), eventWithUsedCount.issuedCount(), eventWithUsedCount.usedCouponCount()),
+                eventWithUsedCount.createdAt(),
+                eventWithUsedCount.updatedA()
         );
     }
 }

--- a/src/main/java/com/sparta/couponpop/domain/couponevent/dto/response/EventStatisticSummary.java
+++ b/src/main/java/com/sparta/couponpop/domain/couponevent/dto/response/EventStatisticSummary.java
@@ -24,4 +24,17 @@ public record EventStatisticSummary(
                 unused
         );
     }
+
+    public static EventStatisticSummary of(int total, int issued, int usedCouponCount) {
+        int unused = issued - usedCouponCount;
+        int unclaimed = total - issued;
+
+        return new EventStatisticSummary(
+                total,
+                unclaimed,
+                issued,
+                usedCouponCount,
+                unused
+        );
+    }
 }

--- a/src/main/java/com/sparta/couponpop/domain/couponevent/dto/response/StoreCouponEventListResponse.java
+++ b/src/main/java/com/sparta/couponpop/domain/couponevent/dto/response/StoreCouponEventListResponse.java
@@ -1,6 +1,6 @@
 package com.sparta.couponpop.domain.couponevent.dto.response;
 
-import com.sparta.couponpop.domain.couponevent.repository.dto.StoreCouponEventsCursor;
+import com.sparta.couponpop.domain.couponevent.dto.cursor.StoreCouponEventsCursor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/sparta/couponpop/domain/couponevent/dto/response/StoreCouponEventListResponse.java
+++ b/src/main/java/com/sparta/couponpop/domain/couponevent/dto/response/StoreCouponEventListResponse.java
@@ -1,0 +1,51 @@
+package com.sparta.couponpop.domain.couponevent.dto.response;
+
+import com.sparta.couponpop.domain.couponevent.repository.dto.StoreCouponEventsCursor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public record StoreCouponEventListResponse(
+        Long storeId,
+        String storeName,
+        List<CouponEventDetailResponse> events,
+        StoreCouponEventsCursor nextCursor,
+        int size,
+        boolean hasNext
+) {
+    public static StoreCouponEventListResponse of(
+            Long storeId,
+            String storeName,
+            List<CouponEventDetailResponse> originalEvents,
+            int pageSize
+    ) {
+        boolean hasNext = originalEvents.size() > pageSize;
+        List<CouponEventDetailResponse> events = trimToPageSize(originalEvents, pageSize);
+        StoreCouponEventsCursor cursor = hasNext ? buildNextCursor(events) : null;
+
+        return new StoreCouponEventListResponse(storeId, storeName, events, cursor, pageSize, hasNext);
+    }
+
+    private static List<CouponEventDetailResponse> trimToPageSize(List<CouponEventDetailResponse> events, int pageSize) {
+        if (events.size() <= pageSize) {
+            return events;
+        }
+        // 원본 리스트 변형 방지를 위해 복사 후 제거
+        List<CouponEventDetailResponse> trimmed = new ArrayList<>(events);
+        trimmed.remove(trimmed.size() - 1);
+        return trimmed;
+    }
+
+    private static StoreCouponEventsCursor buildNextCursor(List<CouponEventDetailResponse> events) {
+        if (events.isEmpty()) {
+            return null;
+        }
+
+        CouponEventDetailResponse lastEvent = events.get(events.size() - 1);
+        return new StoreCouponEventsCursor(
+                lastEvent.eventPeriod().start(),
+                lastEvent.eventPeriod().end(),
+                lastEvent.id()
+        );
+    }
+}

--- a/src/main/java/com/sparta/couponpop/domain/couponevent/repository/CouponEventQueryRepository.java
+++ b/src/main/java/com/sparta/couponpop/domain/couponevent/repository/CouponEventQueryRepository.java
@@ -2,7 +2,7 @@ package com.sparta.couponpop.domain.couponevent.repository;
 
 import com.sparta.couponpop.domain.couponevent.enums.CouponEventStatus;
 import com.sparta.couponpop.domain.couponevent.repository.dto.CouponEventWithUsedCountProjection;
-import com.sparta.couponpop.domain.couponevent.repository.dto.StoreCouponEventsCursor;
+import com.sparta.couponpop.domain.couponevent.dto.cursor.StoreCouponEventsCursor;
 import com.sparta.couponpop.domain.store.entity.Store;
 
 import java.util.List;

--- a/src/main/java/com/sparta/couponpop/domain/couponevent/repository/CouponEventQueryRepository.java
+++ b/src/main/java/com/sparta/couponpop/domain/couponevent/repository/CouponEventQueryRepository.java
@@ -1,0 +1,18 @@
+package com.sparta.couponpop.domain.couponevent.repository;
+
+import com.sparta.couponpop.domain.couponevent.enums.CouponEventStatus;
+import com.sparta.couponpop.domain.couponevent.repository.dto.CouponEventWithUsedCountProjection;
+import com.sparta.couponpop.domain.couponevent.repository.dto.StoreCouponEventsCursor;
+import com.sparta.couponpop.domain.store.entity.Store;
+
+import java.util.List;
+
+public interface CouponEventQueryRepository {
+
+    List<CouponEventWithUsedCountProjection> fetchCouponEventsByStoreAndStatus(
+            Store store,
+            CouponEventStatus eventStatus,
+            StoreCouponEventsCursor cursor,
+            int limit
+    );
+}

--- a/src/main/java/com/sparta/couponpop/domain/couponevent/repository/CouponEventQueryRepositoryImpl.java
+++ b/src/main/java/com/sparta/couponpop/domain/couponevent/repository/CouponEventQueryRepositoryImpl.java
@@ -1,0 +1,108 @@
+package com.sparta.couponpop.domain.couponevent.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.couponpop.domain.coupon.entity.QCoupon;
+import com.sparta.couponpop.domain.coupon.enums.CouponStatus;
+import com.sparta.couponpop.domain.couponevent.entity.QCouponEvent;
+import com.sparta.couponpop.domain.couponevent.enums.CouponEventStatus;
+import com.sparta.couponpop.domain.couponevent.repository.dto.CouponEventWithUsedCountProjection;
+import com.sparta.couponpop.domain.couponevent.repository.dto.QCouponEventWithUsedCountProjection;
+import com.sparta.couponpop.domain.couponevent.repository.dto.StoreCouponEventsCursor;
+import com.sparta.couponpop.domain.store.entity.Store;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.ObjectUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public class CouponEventQueryRepositoryImpl implements CouponEventQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<CouponEventWithUsedCountProjection> fetchCouponEventsByStoreAndStatus(
+            Store store,
+            CouponEventStatus eventStatus,
+            StoreCouponEventsCursor cursor,
+            int limit
+    ) {
+
+        QCouponEvent couponEvent = QCouponEvent.couponEvent;
+        QCoupon coupon = QCoupon.coupon;
+
+        return jpaQueryFactory
+                .select(
+                        new QCouponEventWithUsedCountProjection(
+                                couponEvent.id,
+                                couponEvent.name,
+                                couponEvent.eventStartAt,
+                                couponEvent.eventEndAt,
+                                couponEvent.couponEventStatus,
+                                couponEvent.totalCount,
+                                couponEvent.issuedCount,
+                                coupon.count().intValue(),
+                                couponEvent.createdAt,
+                                couponEvent.updatedAt
+                        )
+                )
+                .from(couponEvent)
+                .leftJoin(coupon).on(
+                        coupon.couponEvent.eq(couponEvent)
+                                .and(coupon.couponStatus.eq(CouponStatus.USED))
+                )
+                .where(
+                        storeEq(couponEvent, store),
+                        eventStatusEq(couponEvent, eventStatus),
+                        nextEventCondition(couponEvent, cursor.lastStartAt(), cursor.lastEndAt(), cursor.lastEventId())
+                )
+                .groupBy(couponEvent.id)
+                .orderBy(
+                        couponEvent.eventStartAt.asc(),
+                        couponEvent.eventEndAt.asc(),
+                        couponEvent.id.asc()
+                )
+                .limit(limit)
+                .fetch();
+    }
+
+    private BooleanExpression storeEq(QCouponEvent couponEvent, Store store) {
+        if (ObjectUtils.isEmpty(store)) {
+            return null;
+        }
+        return couponEvent.store.eq(store);
+    }
+
+    private BooleanExpression eventStatusEq(QCouponEvent couponEvent, CouponEventStatus eventStatus) {
+        if (ObjectUtils.isEmpty(eventStatus)) {
+            return null;
+        }
+        return couponEvent.couponEventStatus.eq(eventStatus);
+    }
+
+    /**
+     * no-offset 페이징 조건:
+     * 1) eventStartAt > lastStartAt 이면 다음 페이지
+     * 2) eventStartAt 같으면 eventEndAt > lastEndAt
+     * 3) 둘 다 같으면 id > lastEventId
+     */
+    private BooleanExpression nextEventCondition(QCouponEvent couponEvent, LocalDateTime lastStartAt, LocalDateTime lastEndAt, Long lastEventId) {
+        if (lastStartAt == null || lastEndAt == null || lastEventId == null) {
+            return null;
+        }
+
+        return couponEvent.eventStartAt.gt(lastStartAt)
+                .or(
+                        couponEvent.eventStartAt.eq(lastStartAt)
+                                .and(couponEvent.eventEndAt.gt(lastEndAt))
+                )
+                .or(
+                        couponEvent.eventStartAt.eq(lastStartAt)
+                                .and(couponEvent.eventEndAt.eq(lastEndAt))
+                                .and(couponEvent.id.gt(lastEventId))
+                );
+    }
+}

--- a/src/main/java/com/sparta/couponpop/domain/couponevent/repository/CouponEventQueryRepositoryImpl.java
+++ b/src/main/java/com/sparta/couponpop/domain/couponevent/repository/CouponEventQueryRepositoryImpl.java
@@ -8,7 +8,7 @@ import com.sparta.couponpop.domain.couponevent.entity.QCouponEvent;
 import com.sparta.couponpop.domain.couponevent.enums.CouponEventStatus;
 import com.sparta.couponpop.domain.couponevent.repository.dto.CouponEventWithUsedCountProjection;
 import com.sparta.couponpop.domain.couponevent.repository.dto.QCouponEventWithUsedCountProjection;
-import com.sparta.couponpop.domain.couponevent.repository.dto.StoreCouponEventsCursor;
+import com.sparta.couponpop.domain.couponevent.dto.cursor.StoreCouponEventsCursor;
 import com.sparta.couponpop.domain.store.entity.Store;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/sparta/couponpop/domain/couponevent/repository/CouponEventRepository.java
+++ b/src/main/java/com/sparta/couponpop/domain/couponevent/repository/CouponEventRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
-public interface CouponEventRepository extends JpaRepository<CouponEvent, Long> {
+public interface CouponEventRepository extends JpaRepository<CouponEvent, Long>, CouponEventQueryRepository {
 
     @Query("""
             SELECT e

--- a/src/main/java/com/sparta/couponpop/domain/couponevent/repository/dto/CouponEventWithUsedCountProjection.java
+++ b/src/main/java/com/sparta/couponpop/domain/couponevent/repository/dto/CouponEventWithUsedCountProjection.java
@@ -1,0 +1,23 @@
+package com.sparta.couponpop.domain.couponevent.repository.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import com.sparta.couponpop.domain.couponevent.enums.CouponEventStatus;
+
+import java.time.LocalDateTime;
+
+public record CouponEventWithUsedCountProjection(
+        Long id, String
+        eventName,
+        LocalDateTime start,
+        LocalDateTime end,
+        CouponEventStatus eventStatus,
+        int totalCount,
+        int issuedCount,
+        int usedCouponCount,
+        LocalDateTime createdAt,
+        LocalDateTime updatedA
+) {
+    @QueryProjection
+    public CouponEventWithUsedCountProjection {
+    }
+}

--- a/src/main/java/com/sparta/couponpop/domain/couponevent/repository/dto/CouponEventWithUsedCountProjection.java
+++ b/src/main/java/com/sparta/couponpop/domain/couponevent/repository/dto/CouponEventWithUsedCountProjection.java
@@ -6,8 +6,8 @@ import com.sparta.couponpop.domain.couponevent.enums.CouponEventStatus;
 import java.time.LocalDateTime;
 
 public record CouponEventWithUsedCountProjection(
-        Long id, String
-        eventName,
+        Long id,
+        String eventName,
         LocalDateTime start,
         LocalDateTime end,
         CouponEventStatus eventStatus,
@@ -15,7 +15,7 @@ public record CouponEventWithUsedCountProjection(
         int issuedCount,
         int usedCouponCount,
         LocalDateTime createdAt,
-        LocalDateTime updatedA
+        LocalDateTime updatedAt
 ) {
     @QueryProjection
     public CouponEventWithUsedCountProjection {

--- a/src/main/java/com/sparta/couponpop/domain/couponevent/repository/dto/StoreCouponEventsCursor.java
+++ b/src/main/java/com/sparta/couponpop/domain/couponevent/repository/dto/StoreCouponEventsCursor.java
@@ -13,7 +13,7 @@ public record StoreCouponEventsCursor(
     }
 
     public static StoreCouponEventsCursor ofNullable(LocalDateTime lastStartAt, LocalDateTime lastEndAt, Long lastEventId) {
-        return (lastStartAt != null && lastEndAt != null & lastEventId != null) ?
+        return (lastStartAt != null && lastEndAt != null && lastEventId != null) ?
                 new StoreCouponEventsCursor(lastStartAt, lastEndAt, lastEventId) :
                 StoreCouponEventsCursor.first();
     }

--- a/src/main/java/com/sparta/couponpop/domain/couponevent/repository/dto/StoreCouponEventsCursor.java
+++ b/src/main/java/com/sparta/couponpop/domain/couponevent/repository/dto/StoreCouponEventsCursor.java
@@ -1,0 +1,20 @@
+package com.sparta.couponpop.domain.couponevent.repository.dto;
+
+import java.time.LocalDateTime;
+
+public record StoreCouponEventsCursor(
+        LocalDateTime lastStartAt,
+        LocalDateTime lastEndAt,
+        Long lastEventId
+) {
+
+    public static StoreCouponEventsCursor first() {
+        return new StoreCouponEventsCursor(null, null, null);
+    }
+
+    public static StoreCouponEventsCursor ofNullable(LocalDateTime lastStartAt, LocalDateTime lastEndAt, Long lastEventId) {
+        return (lastStartAt != null && lastEndAt != null & lastEventId != null) ?
+                new StoreCouponEventsCursor(lastStartAt, lastEndAt, lastEventId) :
+                StoreCouponEventsCursor.first();
+    }
+}

--- a/src/main/java/com/sparta/couponpop/domain/couponevent/service/CouponEventService.java
+++ b/src/main/java/com/sparta/couponpop/domain/couponevent/service/CouponEventService.java
@@ -11,7 +11,7 @@ import com.sparta.couponpop.domain.couponevent.entity.CouponEvent;
 import com.sparta.couponpop.domain.couponevent.enums.CouponEventStatus;
 import com.sparta.couponpop.domain.couponevent.exception.CouponEventErrorCode;
 import com.sparta.couponpop.domain.couponevent.repository.CouponEventRepository;
-import com.sparta.couponpop.domain.couponevent.repository.dto.StoreCouponEventsCursor;
+import com.sparta.couponpop.domain.couponevent.dto.cursor.StoreCouponEventsCursor;
 import com.sparta.couponpop.domain.store.entity.Store;
 import com.sparta.couponpop.domain.store.exception.StoreErrorCode;
 import com.sparta.couponpop.domain.store.repository.StoreRepository;

--- a/src/main/java/com/sparta/couponpop/domain/couponevent/service/CouponEventService.java
+++ b/src/main/java/com/sparta/couponpop/domain/couponevent/service/CouponEventService.java
@@ -6,10 +6,14 @@ import com.sparta.couponpop.domain.coupon.repository.CouponRepository;
 import com.sparta.couponpop.domain.couponevent.dto.request.CreateCouponEventRequest;
 import com.sparta.couponpop.domain.couponevent.dto.response.CouponEventDetailResponse;
 import com.sparta.couponpop.domain.couponevent.dto.response.CreateCouponEventResponse;
+import com.sparta.couponpop.domain.couponevent.dto.response.StoreCouponEventListResponse;
 import com.sparta.couponpop.domain.couponevent.entity.CouponEvent;
+import com.sparta.couponpop.domain.couponevent.enums.CouponEventStatus;
 import com.sparta.couponpop.domain.couponevent.exception.CouponEventErrorCode;
 import com.sparta.couponpop.domain.couponevent.repository.CouponEventRepository;
+import com.sparta.couponpop.domain.couponevent.repository.dto.StoreCouponEventsCursor;
 import com.sparta.couponpop.domain.store.entity.Store;
+import com.sparta.couponpop.domain.store.exception.StoreErrorCode;
 import com.sparta.couponpop.domain.store.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -29,6 +34,7 @@ public class CouponEventService {
 
     private static final long MAX_EVENT_HOURS = 48L; // 이벤트 최대 기간(시간)
 
+    // TODO : 정확한 시간? 에 이벤트를 어떻게 시작할 수 있을까?
     @Transactional
     public CreateCouponEventResponse createCouponEvent(CreateCouponEventRequest request, Long userId) {
         /*
@@ -56,6 +62,34 @@ public class CouponEventService {
         couponEvent.validateOwner(loginUserId);
         int usedCouponCount = couponRepository.countByEventIdAndStatus(eventId, CouponStatus.USED);
         return CouponEventDetailResponse.of(couponEvent, usedCouponCount, now);
+    }
+
+    /**
+     * 매장별 쿠폰 이벤트 목록 조회 (Cursor 기반 페이징)
+     *
+     * @param memberId    요청한 회원 ID
+     * @param storeId     조회할 매장 ID
+     * @param eventStatus 조회할 이벤트 상태 (예: IN_PROGRESS)
+     * @param cursor      이전 페이지 마지막 이벤트 정보를 담은 커서
+     * @param pageSize    한 페이지당 조회할 이벤트 수
+     * @return StoreCouponEventListResponse 페이징된 이벤트 목록 및 다음 커서 정보
+     * @throws GlobalException 매장을 찾을 수 없거나, 회원이 매장 소유자가 아닌 경우 발생
+     */
+    public StoreCouponEventListResponse getCouponEventsByStore(Long memberId, Long storeId, CouponEventStatus eventStatus, StoreCouponEventsCursor cursor, int pageSize) {
+        // 매장 조회 및 소유자 검증
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new GlobalException(StoreErrorCode.STORE_NOT_FOUND));
+
+        if (!store.getMember().getId().equals(memberId)) {
+            throw new GlobalException(StoreErrorCode.STORE_ACCESS_PERMISSION_DENIED);
+        }
+
+        // Store 의 eventStatus 이벤트 목록 조회
+        List<CouponEventDetailResponse> couponEventDetailResponses = couponEventRepository.fetchCouponEventsByStoreAndStatus(store, eventStatus, cursor, pageSize + 1).stream()
+                .map(CouponEventDetailResponse::of)
+                .toList();
+
+        return StoreCouponEventListResponse.of(store.getId(), store.getName(), couponEventDetailResponses, pageSize);
     }
 
     private void validateEventDuration(LocalDateTime start, LocalDateTime end) {

--- a/src/test/java/com/sparta/couponpop/domain/couponevent/controller/CouponEventControllerTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/couponevent/controller/CouponEventControllerTest.java
@@ -6,16 +6,14 @@ import com.sparta.couponpop.common.security.JwtAuthenticationToken;
 import com.sparta.couponpop.common.security.JwtProvider;
 import com.sparta.couponpop.common.security.dto.AuthMember;
 import com.sparta.couponpop.domain.couponevent.dto.request.CreateCouponEventRequest;
-import com.sparta.couponpop.domain.couponevent.dto.response.CouponEventDetailResponse;
-import com.sparta.couponpop.domain.couponevent.dto.response.CreateCouponEventResponse;
-import com.sparta.couponpop.domain.couponevent.dto.response.EventPeriod;
-import com.sparta.couponpop.domain.couponevent.dto.response.EventStatisticSummary;
+import com.sparta.couponpop.domain.couponevent.dto.response.*;
 import com.sparta.couponpop.domain.couponevent.enums.CouponEventStatus;
 import com.sparta.couponpop.domain.couponevent.service.CouponEventService;
 import com.sparta.couponpop.domain.member.enums.MemberType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -27,6 +25,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -141,5 +141,74 @@ class CouponEventControllerTest {
                 .andExpect(jsonPath("$.data.eventName").value("아이스 아메리카노 1+1"))
                 .andExpect(jsonPath("$.data.eventStatus").value(CouponEventStatus.SCHEDULED.name()))
         ;
+    }
+
+    @Test
+    @DisplayName("Cursor 기반 페이지 조회 - 성공")
+    void getCouponEventsByStore_withCursor() throws Exception {
+        // given
+        Long storeId = 1L;
+
+        // Mock 15개의 이벤트
+        List<CouponEventDetailResponse> allEvents = new ArrayList<>();
+        for (int i = 1; i <= 15; i++) {
+            CouponEventDetailResponse event = new CouponEventDetailResponse(
+                    (long) i,
+                    "이벤트 " + i,
+                    new EventPeriod(
+                            LocalDateTime.of(2025, 10, 22,4 + i, 0),
+                            LocalDateTime.of(2025, 10, 22, 5 + i, 0)
+                    ),
+                    CouponEventStatus.IN_PROGRESS,
+                    new EventStatisticSummary(100, 50, 50, 25, 25),
+                    LocalDateTime.now(),
+                    LocalDateTime.now()
+            );
+            allEvents.add(event);
+        }
+
+        // 페이지 1
+        StoreCouponEventListResponse page1 = StoreCouponEventListResponse.of(
+                storeId,
+                "테스트 매장",
+                allEvents.subList(0, 11),
+                10
+        );
+
+        // 페이지 2
+        StoreCouponEventListResponse page2 = StoreCouponEventListResponse.of(
+                storeId,
+                "테스트 매장",
+                allEvents.subList(10, 15),
+                10
+        );
+
+        BDDMockito.given(couponEventService.getCouponEventsByStore(anyLong(), anyLong(), any(CouponEventStatus.class), any(), any(Integer.class)))
+                .willReturn(page1)
+                .willReturn(page2);
+
+        // when & then
+        // 첫 페이지 호출
+        mockMvc.perform(
+                        get("/api/v1/owner/stores/{storeId}/coupons/events", storeId)
+                                .param("size", "10")
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.events.length()").value(10))
+                .andExpect(jsonPath("$.data.hasNext").value(true))
+                .andExpect(jsonPath("$.data.nextCursor.lastEventId").value(10));
+
+        // 두 번째 페이지 호출
+        mockMvc.perform(
+                        get("/api/v1/owner/stores/{storeId}/coupons/events", storeId)
+                                .param("size", "10")
+                                .param("lastStartAt", page1.nextCursor().lastStartAt().toString())
+                                .param("lastEndAt", page1.nextCursor().lastEndAt().toString())
+                                .param("lastEventId", page1.nextCursor().lastEventId().toString())
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.events.length()").value(5))
+                .andExpect(jsonPath("$.data.hasNext").value(false))
+                .andExpect(jsonPath("$.data.nextCursor").doesNotExist());
     }
 }

--- a/src/test/java/com/sparta/couponpop/domain/couponevent/service/CouponEventServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/couponevent/service/CouponEventServiceTest.java
@@ -6,10 +6,13 @@ import com.sparta.couponpop.domain.coupon.repository.CouponRepository;
 import com.sparta.couponpop.domain.couponevent.dto.request.CreateCouponEventRequest;
 import com.sparta.couponpop.domain.couponevent.dto.response.CouponEventDetailResponse;
 import com.sparta.couponpop.domain.couponevent.dto.response.CreateCouponEventResponse;
+import com.sparta.couponpop.domain.couponevent.dto.response.StoreCouponEventListResponse;
 import com.sparta.couponpop.domain.couponevent.entity.CouponEvent;
 import com.sparta.couponpop.domain.couponevent.enums.CouponEventStatus;
 import com.sparta.couponpop.domain.couponevent.exception.CouponEventErrorCode;
 import com.sparta.couponpop.domain.couponevent.repository.CouponEventRepository;
+import com.sparta.couponpop.domain.couponevent.repository.dto.CouponEventWithUsedCountProjection;
+import com.sparta.couponpop.domain.couponevent.repository.dto.StoreCouponEventsCursor;
 import com.sparta.couponpop.domain.member.entity.Member;
 import com.sparta.couponpop.domain.store.entity.Store;
 import com.sparta.couponpop.domain.store.repository.StoreRepository;
@@ -23,13 +26,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -219,4 +222,133 @@ class CouponEventServiceTest {
         }
     }
 
+    @Nested
+    @DisplayName("매장 별 이벤트 목록 조회")
+    class GetCouponEventsByStoreTests {
+
+        private static final LocalDateTime now = LocalDateTime.of(2025, 10, 20, 16, 0);
+
+        private CouponEventWithUsedCountProjection createMockCoupon(Long id, String name, LocalDateTime start, LocalDateTime end) {
+            return new CouponEventWithUsedCountProjection(
+                    id,
+                    name,
+                    start,
+                    end,
+                    CouponEventStatus.IN_PROGRESS,
+                    100,
+                    50,
+                    25,
+                    LocalDateTime.now().minusDays(2),
+                    LocalDateTime.now().minusDays(1)
+            );
+        }
+
+        @Test
+        @DisplayName("첫 페이지 조회 - hasNext true")
+        void getCouponEventsByStore_firstPage_hasNextTrue() {
+            // given
+            var cursor = StoreCouponEventsCursor.first();
+            List<CouponEventWithUsedCountProjection> mockedProjections = List.of(
+                    createMockCoupon(1L, "이벤트1", now.minusDays(1), now.plusDays(1)),
+                    createMockCoupon(2L, "이벤트2", now.minusDays(1), now.plusDays(1)),
+                    createMockCoupon(3L, "이벤트3", now.minusDays(1), now.plusDays(1))
+            );
+            int pageSize = 2;
+
+            Member member = TestUtils.createEntity(Member.class, Map.of("id", 1L));
+            Store store = TestUtils.createEntity(Store.class, Map.of(
+                    "id", 1L,
+                    "name", "매장",
+                    "member", member
+            ));
+
+            given(storeRepository.findById(store.getId())).willReturn(Optional.of(store));
+            given(couponEventRepository.fetchCouponEventsByStoreAndStatus(any(Store.class), any(CouponEventStatus.class), any(StoreCouponEventsCursor.class), eq(pageSize + 1)))
+                    .willReturn(mockedProjections);
+
+            // when
+            StoreCouponEventListResponse response = couponEventService.getCouponEventsByStore(member.getId(), store.getId(), CouponEventStatus.IN_PROGRESS, cursor, pageSize);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.storeId()).isEqualTo(store.getId());
+            assertThat(response.storeName()).isEqualTo(store.getName());
+            assertThat(response.events()).hasSizeLessThanOrEqualTo(2); // pageSize
+            assertThat(response.nextCursor()).isNotNull();
+            assertThat(response.nextCursor().lastEventId()).isEqualTo(2L);
+        }
+
+        @Test
+        @DisplayName("마지막 페이지 조회 - hasNext false")
+        void getCouponEventsByStore_lastPage_hasNextFalse() {
+            // given
+            LocalDateTime lastStartAt = now.minusDays(1);
+            LocalDateTime lastEndAt = now.plusDays(1);
+            Long lastEventId = 3L;
+            var cursor = StoreCouponEventsCursor.ofNullable(lastStartAt, lastEndAt, lastEventId);
+            int pageSize = 3;
+
+            List<CouponEventWithUsedCountProjection> mockedProjections = List.of(
+                    createMockCoupon(1L, "이벤트1", now.minusDays(1), now.plusDays(1)),
+                    createMockCoupon(2L, "이벤트2", now.minusDays(1), now.plusDays(1)),
+                    createMockCoupon(lastEventId, "이벤트3", lastStartAt, lastEndAt)
+            );
+
+            Member member = TestUtils.createEntity(Member.class, Map.of("id", 1L));
+            Store store = TestUtils.createEntity(Store.class, Map.of(
+                    "id", 1L,
+                    "name", "매장",
+                    "member", member
+            ));
+
+            given(storeRepository.findById(store.getId())).willReturn(Optional.of(store));
+            given(couponEventRepository.fetchCouponEventsByStoreAndStatus(any(Store.class), any(CouponEventStatus.class), any(StoreCouponEventsCursor.class), eq(pageSize + 1)))
+                    .willReturn(mockedProjections);
+
+            // when
+            StoreCouponEventListResponse response = couponEventService.getCouponEventsByStore(member.getId(), store.getId(), CouponEventStatus.IN_PROGRESS, cursor, pageSize);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.events()).hasSizeLessThanOrEqualTo(3); // pageSize
+            assertThat(response.nextCursor()).isNull();
+        }
+
+        @Test
+        @DisplayName("커서 이후 조회")
+        void getCouponEventsByStore_nextCursorPage() {
+            // given
+            var cursor = StoreCouponEventsCursor.ofNullable(now.minusDays(1), now.plusDays(1), 2L);
+            int pageSize = 2;
+
+            List<CouponEventWithUsedCountProjection> mockedProjections = List.of(
+                    createMockCoupon(3L, "이벤트3", now.minusDays(1), now.plusDays(1)),
+                    createMockCoupon(4L, "이벤트4", now.minusDays(1), now.plusDays(1)),
+                    createMockCoupon(5L, "이벤트5", now.minusDays(1), now.plusDays(1))
+            );
+
+            Member member = TestUtils.createEntity(Member.class, Map.of("id", 1L));
+            Store store = TestUtils.createEntity(Store.class, Map.of(
+                    "id", 1L,
+                    "name", "매장",
+                    "member", member
+            ));
+
+            given(storeRepository.findById(store.getId())).willReturn(Optional.of(store));
+            given(couponEventRepository.fetchCouponEventsByStoreAndStatus(any(Store.class), any(CouponEventStatus.class), any(StoreCouponEventsCursor.class), eq(pageSize + 1)))
+                    .willReturn(mockedProjections);
+
+            // when
+            StoreCouponEventListResponse response = couponEventService.getCouponEventsByStore(
+                    member.getId(), store.getId(), CouponEventStatus.IN_PROGRESS, cursor, pageSize
+            );
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.events()).hasSizeLessThanOrEqualTo(2); // pageSize
+            assertThat(response.nextCursor()).isNotNull();
+            assertThat(response.nextCursor().lastEventId()).isEqualTo(4L);
+        }
+
+    }
 }

--- a/src/test/java/com/sparta/couponpop/domain/couponevent/service/CouponEventServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/couponevent/service/CouponEventServiceTest.java
@@ -12,7 +12,7 @@ import com.sparta.couponpop.domain.couponevent.enums.CouponEventStatus;
 import com.sparta.couponpop.domain.couponevent.exception.CouponEventErrorCode;
 import com.sparta.couponpop.domain.couponevent.repository.CouponEventRepository;
 import com.sparta.couponpop.domain.couponevent.repository.dto.CouponEventWithUsedCountProjection;
-import com.sparta.couponpop.domain.couponevent.repository.dto.StoreCouponEventsCursor;
+import com.sparta.couponpop.domain.couponevent.dto.cursor.StoreCouponEventsCursor;
 import com.sparta.couponpop.domain.member.entity.Member;
 import com.sparta.couponpop.domain.store.entity.Store;
 import com.sparta.couponpop.domain.store.repository.StoreRepository;


### PR DESCRIPTION
## 🔗 **연관된 이슈**
> close #이슈번호
- close #63

<br>

## 📝 **작업 내용**

### 1️⃣ 정상 케이스
| 테스트 | 설명 | 기대 결과 |
|--------|------|-----------|
| Controller | 매장별 이벤트 조회 요청 | `200 OK` 반환, 이벤트 리스트 반환, `nextCursor` 존재 여부 확인 |
| Service | Cursor 기반 페이지 조회 | Projection 반환, `pageSize` 제한 적용, `nextCursor` 계산 확인 |

### 2️⃣ 예외 / 경계 케이스
| 상황 | Controller 결과 | Service 예외 |
|------|----------------|---------------|
| 이벤트 없음 | `200 OK`, 빈 리스트 | 없음 |
| Cursor 범위 초과 | `200 OK`, 빈 리스트 | 없음 |
| pageSize 0 또는 음수 | `400 Bad Request` | Validation 예외 |

### 3️⃣ 핵심 검증 포인트
- Cursor 기반 페이지네이션 동작 확인
  - 첫 페이지, 중간 페이지, 마지막 페이지
  - `hasNext` / `nextCursor` 값 검증
- 이벤트 상태 검증
  - `IN_PROGRESS`, `COMPLETED`, `CANCELED`, `SCHEDULED`
- Projection 데이터 검증
  - 이벤트 통계 (`totalCount`, `issuedCount`, `usedCount`)
- Controller와 Service 호출 일관성 확인
- JSON 응답 구조 확인
  - `storeId`, `storeName`, `events`, `nextCursor`

### 4️⃣ 비고
- Service 단위 테스트는 **Cursor 로직 + Projection 반환** 중심
- Controller 통합 테스트는 **HTTP 상태 + JSON 응답 + Cursor 연계** 검증 중심
- 실제 DB 데이터 없이 Mock 객체 활용 가능
- 페이지 사이즈, Cursor 범위, 이벤트 상태를 다양하게 조합하여 테스트 가능