### PR TITLE
chore: CI 과정에 Jacoco 추가

### DIFF
--- a/.github/workflows/v1-ci-pipeline.yml
+++ b/.github/workflows/v1-ci-pipeline.yml
@@ -60,20 +60,19 @@ jobs:
         run: ./gradlew clean build --no-daemon
 
       - name: Upload JaCoCo Coverage Report
-        if: inputs.branch_name == 'main' || inputs.branch_name == 'chore/cicd-jacoco'
         uses: actions/upload-artifact@v4
         with:
           name: jacoco-html-report
           path: build/jacocoHtml/
 
       - name: Upload Test Report
-        if: inputs.branch_name == 'main' || inputs.branch_name == 'chore/cicd-jacoco'
         uses: actions/upload-artifact@v4
         with:
           name: test-report
           path: build/reports/tests/test
 
-      - name: Test Coverage Report
+      - name: Jacoco Report Comment on PR
+        if: github.event_name == 'pull_request'
         id: jacoco
         uses: madrapps/jacoco-report@v1.7.2
         with:

--- a/.github/workflows/v1-ci-pipeline.yml
+++ b/.github/workflows/v1-ci-pipeline.yml
@@ -30,6 +30,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      pull-requests: write
     outputs:
       image_uri: ${{ steps.build-image.outputs.image_uri }}
 

--- a/.github/workflows/v1-ci-pipeline.yml
+++ b/.github/workflows/v1-ci-pipeline.yml
@@ -60,12 +60,14 @@ jobs:
         run: ./gradlew clean build --no-daemon
 
       - name: Upload JaCoCo Coverage Report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: jacoco-html-report
           path: build/jacocoHtml/
 
       - name: Upload Test Report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-report

--- a/.github/workflows/v1-ci-pipeline.yml
+++ b/.github/workflows/v1-ci-pipeline.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: jacoco-html-report
-          path: build/reports/jacoco/test/html
+          path: build/reports/jacocoHtml/
 
       - name: Upload Test Report
         if: inputs.branch_name == 'main' || inputs.branch_name == 'chore/cicd-jacoco'
@@ -72,6 +72,16 @@ jobs:
         with:
           name: test-report
           path: build/reports/tests/test
+
+      - name: Test Coverage Report
+        id: jacoco
+        uses: madrapps/jacoco-report@v1.7.2
+        with:
+          title: Test Coverage Report
+          paths: ${{ github.workspace }}/build/reports/jacoco/test/jacocoTestReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 60
+          min-coverage-changed-files: 0
 
       - name: Remove secrets
         run: rm -rf src/main/resources/firebase

--- a/.github/workflows/v1-ci-pipeline.yml
+++ b/.github/workflows/v1-ci-pipeline.yml
@@ -59,8 +59,15 @@ jobs:
           REDIS_PORT: 6379
         run: ./gradlew clean build --no-daemon
 
+      - name: Upload JaCoCo Coverage Report
+        if: inputs.branch_name == 'main' || inputs.branch_name == 'chore/cicd-jacoco'
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-html-report
+          path: build/reports/jacoco/test/html
+
       - name: Upload Test Report
-        if: always()
+        if: inputs.branch_name == 'main' || inputs.branch_name == 'chore/cicd-jacoco'
         uses: actions/upload-artifact@v4
         with:
           name: test-report

--- a/.github/workflows/v1-ci-pipeline.yml
+++ b/.github/workflows/v1-ci-pipeline.yml
@@ -83,6 +83,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 60
           min-coverage-changed-files: 0
+          pass-emoji: ':green_circle:'
+          fail-emoji: ':red_circle:'
+          update-comment: true
 
       - name: Remove secrets
         run: rm -rf src/main/resources/firebase

--- a/.github/workflows/v1-ci-pipeline.yml
+++ b/.github/workflows/v1-ci-pipeline.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: jacoco-html-report
-          path: build/reports/jacocoHtml/
+          path: build/jacocoHtml/
 
       - name: Upload Test Report
         if: inputs.branch_name == 'main' || inputs.branch_name == 'chore/cicd-jacoco'

--- a/.github/workflows/v1-main-pipeline.yml
+++ b/.github/workflows/v1-main-pipeline.yml
@@ -36,8 +36,7 @@ jobs:
       contents: read
     with:
       # 현재 브랜치 이름('dev' 또는 'main')을 전달
-      #branch_name: ${{ github.ref_name }}
-      branch_name: main
+      branch_name: ${{ github.ref_name }}
     secrets: inherit
 
   # =================================================================

--- a/.github/workflows/v1-main-pipeline.yml
+++ b/.github/workflows/v1-main-pipeline.yml
@@ -33,6 +33,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      pull-requests: write
     with:
       # 현재 브랜치 이름('dev' 또는 'main')을 전달
       branch_name: ${{ github.ref_name }}

--- a/.github/workflows/v1-main-pipeline.yml
+++ b/.github/workflows/v1-main-pipeline.yml
@@ -3,7 +3,6 @@ name: CouponPop Main CI/CD
 on:
   push:
     branches:
-      - chore/cicd-jacoco
       - dev
       - main
     paths-ignore:

--- a/.github/workflows/v1-main-pipeline.yml
+++ b/.github/workflows/v1-main-pipeline.yml
@@ -3,6 +3,7 @@ name: CouponPop Main CI/CD
 on:
   push:
     branches:
+      - chore/cicd-jacoco
       - dev
       - main
     paths-ignore:
@@ -35,7 +36,8 @@ jobs:
       contents: read
     with:
       # 현재 브랜치 이름('dev' 또는 'main')을 전달
-      branch_name: ${{ github.ref_name }}
+      #branch_name: ${{ github.ref_name }}
+      branch_name: main
     secrets: inherit
 
   # =================================================================

--- a/build.gradle
+++ b/build.gradle
@@ -158,7 +158,7 @@ afterEvaluate {
 tasks.named("jacocoTestCoverageVerification", JacocoCoverageVerification) {
     dependsOn tasks.named('jacocoTestReport')
     violationRules {
-        rule {// Line Coverage 최소 60% 이
+        rule {
             enabled = true
             element = 'BUNDLE'
             limit {

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ plugins {
     id 'org.springframework.boot' version '3.4.10'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'org.flywaydb.flyway' version '11.14.0'
+    id 'jacoco'
 }
 
 flyway {
@@ -17,6 +18,10 @@ flyway {
     baselineOnMigrate = true
     baselineVersion = 1
     cleanDisabled = true
+}
+
+jacoco {
+    toolVersion = "0.8.14"
 }
 
 group = 'com.sparta'
@@ -95,6 +100,77 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
+}
+
+def jacocoExcludes = [
+        // --- Spring Boot/JPA 관련 ---
+        '**/configuration/**',        // Configuration 클래스 (예: WebSecurityConfig)
+        '**/config/**',               // Config 클래스 (예: AppConfig)
+        '**/dto/**',                  // DTO (데이터 전송 객체)
+        '**/exception/**',            // 사용자 정의 Exception 클래스
+        '**/error/**',                // Error 핸들러/응답 클래스
+        '**/filter/**',               // Servlet Filter (테스트하기 복잡하거나 Spring Security가 대체)
+        '**/handler/**',              // Global Exception Handler (테스트 복잡)
+        '**/security/**',             // Security 관련 설정 클래스 (예: JwtAuthenticationFilter)
+        '**/util/**',                 // 간단한 유틸성 클래스 중 테스트 불필요한 경우
+
+        // --- QueryDSL 관련 ---
+        '**/Q*.class',                // QueryDSL Q-Class (QClass는 자동으로 생성되므로 제외)
+
+        // --- 기타 생성 코드 ---
+        '**/_*.class',                // Lombok 등 코드 생성 패턴 (때때로 필요)
+        '**/*Application.class',      // 메인 애플리케이션 클래스
+        '**/*Config.class',           // 주요 설정 클래스 (위의 configuration과 중복될 수 있으나 명시적으로)
+        '**/Test*.class',             // 테스트 코드 자체 (중복이 될 수 있지만 안전하게 제외)
+
+        // --- Flyway 관련 ---
+        '**/db/migration/**',         // Flyway 마이그레이션 스크립트
+]
+
+tasks.named('jacocoTestReport', JacocoReport) {
+    dependsOn test
+    reports {
+        xml.required = true
+        csv.required = false
+        html.outputLocation.set(layout.buildDirectory.dir('jacocoHtml'))
+    }
+}
+
+afterEvaluate {
+    tasks.named('jacocoTestReport', JacocoReport).configure {
+        classDirectories.setFrom(
+                files(classDirectories.files.collect {
+                    fileTree(dir: it, exclude: jacocoExcludes)
+                })
+        )
+    }
+
+    tasks.named('jacocoTestCoverageVerification', JacocoCoverageVerification).configure {
+        classDirectories.setFrom(
+                files(classDirectories.files.collect {
+                    fileTree(dir: it, exclude: jacocoExcludes)
+                })
+        )
+    }
+}
+
+tasks.named("jacocoTestCoverageVerification", JacocoCoverageVerification) {
+    dependsOn tasks.named('jacocoTestReport')
+    violationRules {
+        rule {// Line Coverage 최소 60% 이
+            enabled = true
+            element = 'BUNDLE'
+            limit {
+                counter = 'LINE'
+                minimum = 0.60
+            } // BUNDLE 기준 line covered ratio 60% 이상
+        }
+    }
+}
+
+tasks.named('build') {
+    dependsOn jacocoTestCoverageVerification
 }
 
 clean {

--- a/build.gradle
+++ b/build.gradle
@@ -136,21 +136,15 @@ tasks.named('jacocoTestReport', JacocoReport) {
 }
 
 afterEvaluate {
-    tasks.named('jacocoTestReport', JacocoReport).configure {
+    def configureExclusions = {
         classDirectories.setFrom(
                 files(classDirectories.files.collect {
                     fileTree(dir: it, exclude: jacocoExcludes)
                 })
         )
     }
-
-    tasks.named('jacocoTestCoverageVerification', JacocoCoverageVerification).configure {
-        classDirectories.setFrom(
-                files(classDirectories.files.collect {
-                    fileTree(dir: it, exclude: jacocoExcludes)
-                })
-        )
-    }
+    tasks.named('jacocoTestReport', JacocoReport).configure(configureExclusions)
+    tasks.named('jacocoTestCoverageVerification', JacocoCoverageVerification).configure(configureExclusions)
 }
 
 tasks.named("jacocoTestCoverageVerification", JacocoCoverageVerification) {

--- a/build.gradle
+++ b/build.gradle
@@ -98,35 +98,33 @@ dependencies {
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }
 
+def jacocoExcludes = [
+        // --- Spring Boot/JPA 관련 ---
+        '**/configuration/**',
+        '**/config/**',
+        '**/dto/**',
+        '**/exception/**',
+        '**/error/**',
+        '**/filter/**',
+        '**/handler/**',
+        '**/security/**',
+        '**/util/**',
+
+        // --- QueryDSL 관련 ---
+        '**/Q*.class',
+
+        // --- 기타 생성 코드 ---
+        '**/*Application.class',
+        '**/Test*.class',
+
+        // --- Flyway 관련 ---
+        '**/db/migration/**',
+]
 tasks.named('test') {
     useJUnitPlatform()
     finalizedBy jacocoTestReport
 }
 
-def jacocoExcludes = [
-        // --- Spring Boot/JPA 관련 ---
-        '**/configuration/**',        // Configuration 클래스 (예: WebSecurityConfig)
-        '**/config/**',               // Config 클래스 (예: AppConfig)
-        '**/dto/**',                  // DTO (데이터 전송 객체)
-        '**/exception/**',            // 사용자 정의 Exception 클래스
-        '**/error/**',                // Error 핸들러/응답 클래스
-        '**/filter/**',               // Servlet Filter (테스트하기 복잡하거나 Spring Security가 대체)
-        '**/handler/**',              // Global Exception Handler (테스트 복잡)
-        '**/security/**',             // Security 관련 설정 클래스 (예: JwtAuthenticationFilter)
-        '**/util/**',                 // 간단한 유틸성 클래스 중 테스트 불필요한 경우
-
-        // --- QueryDSL 관련 ---
-        '**/Q*.class',                // QueryDSL Q-Class (QClass는 자동으로 생성되므로 제외)
-
-        // --- 기타 생성 코드 ---
-        '**/_*.class',                // Lombok 등 코드 생성 패턴 (때때로 필요)
-        '**/*Application.class',      // 메인 애플리케이션 클래스
-        '**/*Config.class',           // 주요 설정 클래스 (위의 configuration과 중복될 수 있으나 명시적으로)
-        '**/Test*.class',             // 테스트 코드 자체 (중복이 될 수 있지만 안전하게 제외)
-
-        // --- Flyway 관련 ---
-        '**/db/migration/**',         // Flyway 마이그레이션 스크립트
-]
 
 tasks.named('jacocoTestReport', JacocoReport) {
     dependsOn test


### PR DESCRIPTION
## 🔗 **연관된 이슈**
> close #이슈번호

<br>

- close #97 

## 📝 **작업 내용**

1. Jacoco 의존성 추가
2. Jacoco 정책 구성
3. 테스트 커버리지 결과 comment로 알려주는 github actions PR 봇 플러그인 추가

- **Jacoco 정책**
  - 패키지(BUNDLE) 기준 line 커버리지 60% 이상이여 build 성공
  - 새로 추가된 코드에만 별도의 정책을 규정하진 않음
  - 아래의 파일들에 대해서는 커버리지 산정에서 제외, 의견 있으시면 남겨주세요.
  ```groovy
        // --- Spring Boot/JPA 관련 ---
        '**/configuration/**',
        '**/config/**',
        '**/dto/**',
        '**/exception/**',
        '**/error/**',
        '**/filter/**',
        '**/handler/**',
        '**/security/**',
        '**/util/**',

        // --- QueryDSL 관련 ---
        '**/Q*.class',

        // --- 기타 생성 코드 ---
        '**/*Application.class',
        '**/Test*.class',

        // --- Flyway 관련 ---
        '**/db/migration/**'

<br>

## 📸 **스크린샷**
### 적용 완료
 - 작업 내용의 3번은 Jacoco 자체 기능은 아니나, github marketplace에 존재하여 적용했습니다.
   - https://github.com/marketplace/actions/jacoco-report
 - PR에 새로운 Commit이 올라오면 새로 Comment를 달지 않고, 기존 Comment를 업데이트합니다. 기존 결과도 남기도록 comment를 다는 방식도 가능하니, 새로 추가하는 게 낫다고 생각하시면 알려주세요.
<img width="1185" height="629" alt="image" src="https://github.com/user-attachments/assets/3eeb90de-9551-4602-862f-f89a3666bf3b" />

