### PR TITLE
feat: 알림 히스토리 구현

### DIFF
--- a/src/main/java/com/sparta/couponpop/CouponPopApplication.java
+++ b/src/main/java/com/sparta/couponpop/CouponPopApplication.java
@@ -2,7 +2,9 @@ package com.sparta.couponpop;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @SpringBootApplication
 public class CouponPopApplication {
 

--- a/src/main/java/com/sparta/couponpop/domain/notification/controller/FcmTestController.java
+++ b/src/main/java/com/sparta/couponpop/domain/notification/controller/FcmTestController.java
@@ -30,7 +30,8 @@ public class FcmTestController {
         log.debug("[+] 푸시 메세지 전송");
 
         // 일반 테스트
-        fcmSendService.sendNotification(request.token(), request.title(), request.body());
+        Long memberId = 1L; // 테스트용 회원 ID
+        fcmSendService.sendNotification(memberId, request.token(), request.title(), request.body());
 
         return ApiResponse.noContent();
     }

--- a/src/main/java/com/sparta/couponpop/domain/notification/service/FcmSendService.java
+++ b/src/main/java/com/sparta/couponpop/domain/notification/service/FcmSendService.java
@@ -2,11 +2,16 @@ package com.sparta.couponpop.domain.notification.service;
 
 import com.google.firebase.messaging.*;
 import com.sparta.couponpop.domain.notification.factory.FcmMessageFactory;
+import com.sparta.couponpop.domain.notificationhistory.dto.payload.NotificationHistoryPayload;
+import com.sparta.couponpop.domain.notificationhistory.enums.NotificationHistoryStatus;
+import com.sparta.couponpop.domain.notificationhistory.enums.NotificationHistoryType;
+import com.sparta.couponpop.domain.notificationhistory.service.NotificationHistoryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -16,29 +21,49 @@ public class FcmSendService {
 
     // FCM 멀티캐스트 API는 한 번의 요청에 최대 500개의 토큰만 허용한다.
     private static final int FCM_MULTICAST_LIMIT = 500;
+    private static final NotificationHistoryType NOTIFICATION_HISTORY_TYPE = NotificationHistoryType.FCM;
 
     private final FcmMessageFactory fcmMessageFactory;
+    private final NotificationHistoryService notificationHistoryService;
 
     // TODO: 발송된 토큰의 lastUsedAt 업데이트 로직 추가 예정
-    public void sendNotification(String token, String title, String body) throws FirebaseMessagingException {
+    public void sendNotification(Long memberId, String token, String title, String body) throws FirebaseMessagingException {
         if (!StringUtils.hasText(token)) {
             log.info("FCM 전송 토큰이 유효하지 않아 전송을 건너뜁니다.");
             return;
         }
 
+        NotificationHistoryStatus status = NotificationHistoryStatus.SUCCESS;
+        String failureReason = null;
+
         Message message = fcmMessageFactory.createMessage(token, title, body);
-        FirebaseMessaging.getInstance().send(message);
+        try {
+            FirebaseMessaging.getInstance().send(message);
+        } catch (FirebaseMessagingException e) {
+            log.error("FCM 전송 중 오류 발생: {}", e.getMessage());
+
+            status = NotificationHistoryStatus.FAILURE;
+            failureReason = e.getMessage();
+
+            throw e; // 예외 재던지기
+        } finally {
+            NotificationHistoryPayload notificationHistoryPayload = NotificationHistoryPayload.of(memberId, NOTIFICATION_HISTORY_TYPE, title, body, status, failureReason);
+            notificationHistoryService.createNotificationHistory(notificationHistoryPayload);
+        }
 
         // TODO: 성공 토큰 lastUsedAt 업데이트
         // TODO: 실패 토큰 삭제 처리
     }
 
     // TODO: 발송된 토큰의 lastUsedAt 업데이트 로직 추가 예정
-    public void sendNotification(List<String> tokens, String title, String body) throws FirebaseMessagingException {
+    public void sendNotification(Long memberId, List<String> tokens, String title, String body) throws FirebaseMessagingException {
         if (tokens == null || tokens.isEmpty()) {
             log.info("FCM 전송 토큰이 비어 있어 전송을 건너뜁니다.");
             return;
         }
+
+        List<NotificationHistoryPayload> historyPayloads = new ArrayList<>();
+        List<List<SendResponse>> allResponses = new ArrayList<>();
 
         for (int start = 0; start < tokens.size(); start += FCM_MULTICAST_LIMIT) {
             int end = Math.min(start + FCM_MULTICAST_LIMIT, tokens.size());
@@ -50,8 +75,37 @@ public class FcmSendService {
             BatchResponse response = FirebaseMessaging.getInstance().sendEachForMulticast(message);
             log.info("[FCM 다건 전송 결과] 성공={} 실패={}", response.getSuccessCount(), response.getFailureCount());
 
+            allResponses.add(response.getResponses());
+
             // TODO: 성공 토큰 lastUsedAt 업데이트
             // TODO: 실패 토큰 삭제 처리
         }
+
+        // 알림 이력 생성
+        for (List<SendResponse> responses : allResponses) {
+            for (SendResponse sendResponse : responses) {
+                NotificationHistoryStatus status;
+                String failureReason = null;
+
+                if (sendResponse.isSuccessful()) {
+                    status = NotificationHistoryStatus.SUCCESS;
+                } else {
+                    status = NotificationHistoryStatus.FAILURE;
+                    failureReason = sendResponse.getException().getMessage();
+                }
+
+                NotificationHistoryPayload payload = NotificationHistoryPayload.of(
+                        memberId,
+                        NOTIFICATION_HISTORY_TYPE,
+                        title,
+                        body,
+                        status,
+                        failureReason
+                );
+                historyPayloads.add(payload);
+            }
+        }
+
+        notificationHistoryService.bulkInsertNotificationHistories(historyPayloads);
     }
 }

--- a/src/main/java/com/sparta/couponpop/domain/notification/service/sender/CouponIssuedNotificationSender.java
+++ b/src/main/java/com/sparta/couponpop/domain/notification/service/sender/CouponIssuedNotificationSender.java
@@ -61,7 +61,7 @@ public class CouponIssuedNotificationSender implements NotificationSender<Coupon
         );
 
         try {
-            fcmSendService.sendNotification(tokens, title, body);
+            fcmSendService.sendNotification(member.getId(), tokens, title, body);
         } catch (FirebaseMessagingException e) {
             log.error("{} 전송 중 오류가 발생했습니다. tokens={}, message={}", notificationTypeDescription, tokens, e.getMessage(), e);
         }

--- a/src/main/java/com/sparta/couponpop/domain/notification/service/sender/LocationBasedCouponEventNotificationSender.java
+++ b/src/main/java/com/sparta/couponpop/domain/notification/service/sender/LocationBasedCouponEventNotificationSender.java
@@ -89,13 +89,14 @@ public class LocationBasedCouponEventNotificationSender implements NotificationS
             }
 
             // 5. FCM 토큰으로 푸시 알림 전송
+            Long memberId = locationCacheValue.memberId();
             String token = locationCacheValue.fcmToken();
 
             String title = NotificationTemplates.LOCATION_BASED_COUPON_EVENT_TITLE.formatted(openStoreCount);
             String body = NotificationTemplates.LOCATION_BASED_COUPON_EVENT_BODY.formatted(openStoreCount, activeCouponEventCount);
 
             try {
-                fcmSendService.sendNotification(token, title, body);
+                fcmSendService.sendNotification(memberId, token, title, body);
             } catch (FirebaseMessagingException e) {
                 log.error("{} 전송 중 오류가 발생했습니다. token={}, message={}", notificationTypeDescription, token, e.getMessage(), e);
             }

--- a/src/main/java/com/sparta/couponpop/domain/notificationhistory/dto/payload/NotificationHistoryPayload.java
+++ b/src/main/java/com/sparta/couponpop/domain/notificationhistory/dto/payload/NotificationHistoryPayload.java
@@ -1,0 +1,18 @@
+package com.sparta.couponpop.domain.notificationhistory.dto.payload;
+
+import com.sparta.couponpop.domain.notificationhistory.enums.NotificationHistoryStatus;
+import com.sparta.couponpop.domain.notificationhistory.enums.NotificationHistoryType;
+
+public record NotificationHistoryPayload(
+        Long memberId,
+        NotificationHistoryType type,
+        String title,
+        String body,
+        NotificationHistoryStatus status,
+        String failureReason
+) {
+
+    public static NotificationHistoryPayload of(Long memberId, NotificationHistoryType type, String title, String body, NotificationHistoryStatus status, String failureReason) {
+        return new NotificationHistoryPayload(memberId, type, title, body, status, failureReason);
+    }
+}

--- a/src/main/java/com/sparta/couponpop/domain/notificationhistory/entity/NotificationHistory.java
+++ b/src/main/java/com/sparta/couponpop/domain/notificationhistory/entity/NotificationHistory.java
@@ -1,0 +1,70 @@
+package com.sparta.couponpop.domain.notificationhistory.entity;
+
+import com.sparta.couponpop.domain.notificationhistory.enums.NotificationHistoryStatus;
+import com.sparta.couponpop.domain.notificationhistory.enums.NotificationHistoryType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notification_histories")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class NotificationHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationHistoryType type;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String body;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationHistoryStatus status;
+
+    private String failureReason;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private NotificationHistory(Long memberId, NotificationHistoryType type, String title, String body, NotificationHistoryStatus status, String failureReason) {
+        this.memberId = memberId;
+        this.type = type;
+        this.title = title;
+        this.body = body;
+        this.status = status;
+        this.failureReason = failureReason;
+    }
+
+    public static NotificationHistory of(Long memberId, NotificationHistoryType type, String title, String body, NotificationHistoryStatus status, String failureReason) {
+        return NotificationHistory.builder()
+                .memberId(memberId)
+                .type(type)
+                .title(title)
+                .body(body)
+                .status(status)
+                .failureReason(failureReason)
+                .build();
+    }
+
+}

--- a/src/main/java/com/sparta/couponpop/domain/notificationhistory/enums/NotificationHistoryStatus.java
+++ b/src/main/java/com/sparta/couponpop/domain/notificationhistory/enums/NotificationHistoryStatus.java
@@ -1,0 +1,6 @@
+package com.sparta.couponpop.domain.notificationhistory.enums;
+
+public enum NotificationHistoryStatus {
+
+    SUCCESS, FAILURE
+}

--- a/src/main/java/com/sparta/couponpop/domain/notificationhistory/enums/NotificationHistoryType.java
+++ b/src/main/java/com/sparta/couponpop/domain/notificationhistory/enums/NotificationHistoryType.java
@@ -1,0 +1,6 @@
+package com.sparta.couponpop.domain.notificationhistory.enums;
+
+public enum NotificationHistoryType {
+
+    FCM
+}

--- a/src/main/java/com/sparta/couponpop/domain/notificationhistory/repository/NotificationHistoryBulkRepository.java
+++ b/src/main/java/com/sparta/couponpop/domain/notificationhistory/repository/NotificationHistoryBulkRepository.java
@@ -1,0 +1,44 @@
+package com.sparta.couponpop.domain.notificationhistory.repository;
+
+import com.sparta.couponpop.domain.notificationhistory.entity.NotificationHistory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationHistoryBulkRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public void bulkInsert(List<NotificationHistory> notificationHistories) {
+        String sql = """
+                    INSERT INTO notification_histories (member_id, type, title, body, status, failure_reason, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?, now())
+                """;
+
+        jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                NotificationHistory history = notificationHistories.get(i);
+                ps.setLong(1, history.getMemberId());
+                ps.setString(2, history.getType().name());
+                ps.setString(3, history.getTitle());
+                ps.setString(4, history.getBody());
+                ps.setString(5, history.getStatus().name());
+                ps.setString(6, history.getFailureReason());
+            }
+
+            @Override
+            public int getBatchSize() {
+                return notificationHistories.size();
+            }
+        });
+    }
+
+}

--- a/src/main/java/com/sparta/couponpop/domain/notificationhistory/repository/NotificationHistoryRepository.java
+++ b/src/main/java/com/sparta/couponpop/domain/notificationhistory/repository/NotificationHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.sparta.couponpop.domain.notificationhistory.repository;
+
+import com.sparta.couponpop.domain.notificationhistory.entity.NotificationHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationHistoryRepository extends JpaRepository<NotificationHistory, Long> {
+}

--- a/src/main/java/com/sparta/couponpop/domain/notificationhistory/service/NotificationHistoryService.java
+++ b/src/main/java/com/sparta/couponpop/domain/notificationhistory/service/NotificationHistoryService.java
@@ -6,6 +6,7 @@ import com.sparta.couponpop.domain.notificationhistory.repository.NotificationHi
 import com.sparta.couponpop.domain.notificationhistory.repository.NotificationHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +27,7 @@ public class NotificationHistoryService {
         notificationHistoryRepository.save(notificationHistory);
     }
 
+    @Async
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void bulkInsertNotificationHistories(List<NotificationHistoryPayload> historyPayloads) {
         List<NotificationHistory> notificationHistories = historyPayloads.stream()

--- a/src/main/java/com/sparta/couponpop/domain/notificationhistory/service/NotificationHistoryService.java
+++ b/src/main/java/com/sparta/couponpop/domain/notificationhistory/service/NotificationHistoryService.java
@@ -1,0 +1,37 @@
+package com.sparta.couponpop.domain.notificationhistory.service;
+
+import com.sparta.couponpop.domain.notificationhistory.dto.payload.NotificationHistoryPayload;
+import com.sparta.couponpop.domain.notificationhistory.entity.NotificationHistory;
+import com.sparta.couponpop.domain.notificationhistory.repository.NotificationHistoryBulkRepository;
+import com.sparta.couponpop.domain.notificationhistory.repository.NotificationHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationHistoryService {
+
+    private final NotificationHistoryRepository notificationHistoryRepository;
+    private final NotificationHistoryBulkRepository notificationHistoryBulkRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void createNotificationHistory(NotificationHistoryPayload payload) {
+        NotificationHistory notificationHistory = NotificationHistory.of(payload.memberId(), payload.type(), payload.title(), payload.body(), payload.status(), payload.failureReason());
+        notificationHistoryRepository.save(notificationHistory);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void bulkInsertNotificationHistories(List<NotificationHistoryPayload> historyPayloads) {
+        List<NotificationHistory> notificationHistories = historyPayloads.stream()
+                .map(payload -> NotificationHistory.of(payload.memberId(), payload.type(), payload.title(), payload.body(), payload.status(), payload.failureReason()))
+                .toList();
+
+        notificationHistoryBulkRepository.bulkInsert(notificationHistories);
+    }
+}

--- a/src/main/resources/db/migration/V13__create_notification_histories_table.sql
+++ b/src/main/resources/db/migration/V13__create_notification_histories_table.sql
@@ -1,0 +1,15 @@
+CREATE TABLE notification_histories
+(
+    id             BIGINT AUTO_INCREMENT PRIMARY KEY,
+    member_id      BIGINT                      NOT NULL COMMENT '알림을 받은 회원 ID',
+    type           ENUM ('FCM')                NOT NULL COMMENT '알림 유형(FCM 등)',
+    title          VARCHAR(255)                NOT NULL COMMENT '알림 제목',
+    body           TEXT                        NOT NULL COMMENT '알림 내용',
+    status         ENUM ('SUCCESS', 'FAILURE') NOT NULL COMMENT '알림 발송 상태',
+    failure_reason VARCHAR(255)                NULL COMMENT '발송 실패 원인',
+    created_at     DATETIME                    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성일',
+
+    KEY idx_notification_histories_member_id (member_id)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci COMMENT ='회원별 알림 발송 이력 저장 테이블';

--- a/src/test/java/com/sparta/couponpop/domain/notification/service/FcmSendServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/notification/service/FcmSendServiceTest.java
@@ -2,6 +2,10 @@ package com.sparta.couponpop.domain.notification.service;
 
 import com.google.firebase.messaging.*;
 import com.sparta.couponpop.domain.notification.factory.FcmMessageFactory;
+import com.sparta.couponpop.domain.notificationhistory.dto.payload.NotificationHistoryPayload;
+import com.sparta.couponpop.domain.notificationhistory.enums.NotificationHistoryStatus;
+import com.sparta.couponpop.domain.notificationhistory.enums.NotificationHistoryType;
+import com.sparta.couponpop.domain.notificationhistory.service.NotificationHistoryService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -21,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -28,6 +33,9 @@ class FcmSendServiceTest {
 
     @Mock
     private FcmMessageFactory fcmMessageFactory;
+
+    @Mock
+    private NotificationHistoryService notificationHistoryService;
 
     @InjectMocks
     private FcmSendService fcmSendService;
@@ -39,6 +47,7 @@ class FcmSendServiceTest {
         @DisplayName("단일 토큰 전송 시 메시지를 생성한다")
         void sendNotification_success_singleToken() throws FirebaseMessagingException {
             // given
+            Long memberId = 1L;
             String token = "test-token";
             String title = "알림 제목";
             String body = "알림 내용";
@@ -60,12 +69,20 @@ class FcmSendServiceTest {
 
             FirebaseMessaging firebaseMessaging = mock(FirebaseMessaging.class);
             given(firebaseMessaging.send(any(Message.class))).willReturn("mock-message-id");
+            NotificationHistoryPayload expectedPayload = NotificationHistoryPayload.of(
+                    memberId,
+                    NotificationHistoryType.FCM,
+                    title,
+                    body,
+                    NotificationHistoryStatus.SUCCESS,
+                    null
+            );
 
             try (MockedStatic<FirebaseMessaging> mockedStatic = mockStatic(FirebaseMessaging.class)) {
                 mockedStatic.when(FirebaseMessaging::getInstance).thenReturn(firebaseMessaging);
 
                 // when
-                fcmSendService.sendNotification(token, title, body);
+                fcmSendService.sendNotification(memberId, token, title, body);
 
                 // then
                 ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
@@ -76,6 +93,7 @@ class FcmSendServiceTest {
                 Notification notification = extractNotification(sentMessage);
                 assertThat(extractNotificationValue(notification, "title")).isEqualTo(title);
                 assertThat(extractNotificationValue(notification, "body")).isEqualTo(body);
+                then(notificationHistoryService).should().createNotificationHistory(expectedPayload);
             }
         }
 
@@ -83,11 +101,12 @@ class FcmSendServiceTest {
         @DisplayName("토큰이 비어 있으면 FCM 전송을 수행하지 않는다")
         void sendNotification_skipSend_tokensEmpty() throws FirebaseMessagingException {
             // given
-            List<String> emptyTokens = Collections.emptyList();
+                Long memberId = 1L;
+                List<String> emptyTokens = Collections.emptyList();
 
             try (MockedStatic<FirebaseMessaging> mockedStatic = mockStatic(FirebaseMessaging.class)) {
                 // when
-                fcmSendService.sendNotification(emptyTokens, "제목", "본문");
+                fcmSendService.sendNotification(memberId, emptyTokens, "제목", "본문");
 
                 // then
                 mockedStatic.verifyNoInteractions();
@@ -99,6 +118,7 @@ class FcmSendServiceTest {
         @DisplayName("토큰이 500개 초과 시 500개 단위로 배치 전송한다")
         void sendNotification_success_tokensExceedLimit() throws FirebaseMessagingException {
             // given
+            Long memberId = 2L;
             List<String> tokens = new ArrayList<>();
             for (int i = 0; i < 750; i++) {
                 tokens.add("token-" + i);
@@ -112,17 +132,30 @@ class FcmSendServiceTest {
                         return buildMessage(requestTokens, requestTitle, requestBody);
                     });
             FirebaseMessaging firebaseMessaging = mock(FirebaseMessaging.class);
-            BatchResponse batchResponse = mock(BatchResponse.class);
+            willAnswer(invocation -> {
+                MulticastMessage multicastMessage = invocation.getArgument(0, MulticastMessage.class);
+                List<String> requestTokens = extractTokens(multicastMessage);
 
-            given(batchResponse.getSuccessCount()).willReturn(500);
-            given(batchResponse.getFailureCount()).willReturn(0);
-            given(firebaseMessaging.sendEachForMulticast(any(MulticastMessage.class))).willReturn(batchResponse);
+                BatchResponse dynamicResponse = mock(BatchResponse.class);
+                List<SendResponse> sendResponses = requestTokens.stream()
+                        .map(token -> {
+                            SendResponse sendResponse = mock(SendResponse.class);
+                            given(sendResponse.isSuccessful()).willReturn(true);
+                            return sendResponse;
+                        })
+                        .toList();
+
+                given(dynamicResponse.getSuccessCount()).willReturn(requestTokens.size());
+                given(dynamicResponse.getFailureCount()).willReturn(0);
+                given(dynamicResponse.getResponses()).willReturn(sendResponses);
+                return dynamicResponse;
+            }).given(firebaseMessaging).sendEachForMulticast(any(MulticastMessage.class));
 
             try (MockedStatic<FirebaseMessaging> mockedStatic = mockStatic(FirebaseMessaging.class)) {
                 mockedStatic.when(FirebaseMessaging::getInstance).thenReturn(firebaseMessaging);
 
                 // when
-                fcmSendService.sendNotification(tokens, "배치 제목", "배치 본문");
+                fcmSendService.sendNotification(memberId, tokens, "배치 제목", "배치 본문");
 
                 // then
                 ArgumentCaptor<MulticastMessage> messageCaptor = ArgumentCaptor.forClass(MulticastMessage.class);
@@ -133,6 +166,16 @@ class FcmSendServiceTest {
                 assertThat(extractTokens(capturedMessages.get(0))).hasSize(500);
                 assertThat(extractTokens(capturedMessages.get(1))).hasSize(250);
                 then(fcmMessageFactory).should(times(2)).createMulticastMessage(anyList(), eq("배치 제목"), eq("배치 본문"));
+                then(notificationHistoryService).should().bulkInsertNotificationHistories(argThat(payloads -> {
+                    assertThat(payloads).hasSize(tokens.size());
+                    assertThat(payloads)
+                            .allMatch(payload -> payload.memberId().equals(memberId)
+                                    && payload.type() == NotificationHistoryType.FCM
+                                    && payload.title().equals("배치 제목")
+                                    && payload.body().equals("배치 본문")
+                                    && payload.status() == NotificationHistoryStatus.SUCCESS);
+                    return true;
+                }));
             }
         }
 

--- a/src/test/java/com/sparta/couponpop/domain/notification/service/sender/CouponIssuedNotificationSenderTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/notification/service/sender/CouponIssuedNotificationSenderTest.java
@@ -107,7 +107,7 @@ class CouponIssuedNotificationSenderTest {
 
             // then
             then(memberFcmTokenRepository).should().findByMemberAndNotificationEnabledIsTrue(member);
-            then(fcmSendService).should(never()).sendNotification(anyList(), anyString(), anyString());
+            then(fcmSendService).should(never()).sendNotification(anyLong(), anyList(), anyString(), anyString());
         }
 
         @Test
@@ -170,6 +170,7 @@ class CouponIssuedNotificationSenderTest {
 
             // then
             then(fcmSendService).should().sendNotification(
+                    eq(memberId),
                     tokensCaptor.capture(),
                     titleCaptor.capture(),
                     bodyCaptor.capture()
@@ -219,7 +220,7 @@ class CouponIssuedNotificationSenderTest {
             given(memberFcmTokenRepository.findByMemberAndNotificationEnabledIsTrue(member)).willReturn(List.of(token));
 
             FirebaseMessagingException messagingException = mock(FirebaseMessagingException.class);
-            willThrow(messagingException).given(fcmSendService).sendNotification(anyList(), anyString(), anyString());
+            willThrow(messagingException).given(fcmSendService).sendNotification(eq(memberId), anyList(), anyString(), anyString());
 
             // when & then
             assertThatCode(() -> sender.send(command)).doesNotThrowAnyException();

--- a/src/test/java/com/sparta/couponpop/domain/notification/service/sender/LocationBasedCouponEventNotificationSenderTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/notification/service/sender/LocationBasedCouponEventNotificationSenderTest.java
@@ -117,7 +117,7 @@ class LocationBasedCouponEventNotificationSenderTest {
                     any(LocalDateTime.class)
             );
             then(redisService).should().deleteKeys(locationKeys);
-            then(fcmSendService).should(never()).sendNotification(anyString(), anyString(), anyString());
+            then(fcmSendService).should(never()).sendNotification(anyLong(), anyString(), anyString(), anyString());
         }
 
         @Test
@@ -154,7 +154,7 @@ class LocationBasedCouponEventNotificationSenderTest {
                     any(LocalDateTime.class)
             );
             then(redisService).should().deleteKeys(locationKeys);
-            then(fcmSendService).should(never()).sendNotification(anyString(), anyString(), anyString());
+            then(fcmSendService).should(never()).sendNotification(anyLong(), anyString(), anyString(), anyString());
         }
 
         @Test
@@ -190,7 +190,7 @@ class LocationBasedCouponEventNotificationSenderTest {
 
             // then
             then(redisService).should().deleteKeys(locationKeys);
-            then(fcmSendService).should().sendNotification(cacheValue.fcmToken(), expectedTitle, expectedBody);
+            then(fcmSendService).should().sendNotification(cacheValue.memberId(), cacheValue.fcmToken(), expectedTitle, expectedBody);
         }
 
         @Test
@@ -218,7 +218,7 @@ class LocationBasedCouponEventNotificationSenderTest {
 
             willThrow(FirebaseMessagingException.class)
                     .given(fcmSendService)
-                    .sendNotification(eq(cacheValue.fcmToken()), anyString(), anyString());
+                    .sendNotification(eq(cacheValue.memberId()), eq(cacheValue.fcmToken()), anyString(), anyString());
 
             // when & then
             assertThatCode(() -> sender.send(LocationBasedCouponEventNotificationCommand.of()))


### PR DESCRIPTION
## 🔗 **연관된 이슈**
> close #이슈번호
- close #84 

<br>

## 📝 **작업 내용**

- 알림 발송 시 DB에 알림 히스토리를 저장

<br>

## 💥 **이슈 내용**

https://www.tldraw.com/f/e5Roz5BijagLg-W4-2Amk?d=v3542.11111.4293.2550.page

- 알림 히스토리 저장 로직이 FCM 전송 로직에 섞여 있어 추후 EDA 도입 시 분리 고려
   - AOP 적용해보았을 때 FCM 전송 결과값들을 넘겨주는 작업이 너무 수동적이라 사이드 이펙트가 클 것 같음
- FCM 에서 제공해주는 다건 발송(Multicast API) 사용 시 각 전송 결과를 받아와서 비동기 bulk insert 처리


<br>

## 📸 **스크린샷 (선택)**

### 알림 히스토리 테이블 구조

<img width="623" height="200" alt="tldrawFile (1)" src="https://github.com/user-attachments/assets/d1f4d19f-6031-4c85-8490-fd8e11a7146b" />

### FCM 발송 및 히스토리 저장 플로우

<img width="366" height="213" alt="image" src="https://github.com/user-attachments/assets/8b283133-bce4-47aa-9ff6-a85ad7558563" />

<br>
