### PR TITLE
feat: 사장 - 매장 별 대시보드 API

### DIFF
--- a/src/main/java/com/sparta/couponpop/domain/couponevent/controller/CouponEventController.java
+++ b/src/main/java/com/sparta/couponpop/domain/couponevent/controller/CouponEventController.java
@@ -3,12 +3,14 @@ package com.sparta.couponpop.domain.couponevent.controller;
 import com.sparta.couponpop.common.response.ApiResponse;
 import com.sparta.couponpop.common.security.annotation.CurrentMember;
 import com.sparta.couponpop.common.security.dto.AuthMember;
+import com.sparta.couponpop.domain.couponevent.dto.cursor.StoreCouponEventsCursor;
+import com.sparta.couponpop.domain.couponevent.dto.cursor.StoreCouponEventsStatisticsCursor;
 import com.sparta.couponpop.domain.couponevent.dto.request.CreateCouponEventRequest;
 import com.sparta.couponpop.domain.couponevent.dto.response.CouponEventDetailResponse;
 import com.sparta.couponpop.domain.couponevent.dto.response.CreateCouponEventResponse;
 import com.sparta.couponpop.domain.couponevent.dto.response.StoreCouponEventListResponse;
+import com.sparta.couponpop.domain.couponevent.dto.response.StoreCouponEventStatisticsResponse;
 import com.sparta.couponpop.domain.couponevent.enums.CouponEventStatus;
-import com.sparta.couponpop.domain.couponevent.dto.cursor.StoreCouponEventsCursor;
 import com.sparta.couponpop.domain.couponevent.service.CouponEventService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -58,5 +60,15 @@ public class CouponEventController {
         return ApiResponse.success(response);
     }
 
+    @GetMapping("/owner/stores/events/statistics")
+    public ResponseEntity<ApiResponse<StoreCouponEventStatisticsResponse>> getStoreCouponEventStatistics(
+            @RequestParam(required = false) Long lastStoreId,
+            @RequestParam(defaultValue = "10") int size,
+            @CurrentMember AuthMember authMember
+    ) {
+        var cursor = StoreCouponEventsStatisticsCursor.ofNullable(lastStoreId);
+        StoreCouponEventStatisticsResponse responses = couponEventService.getStoreCouponEventStatistics(authMember.id(), cursor, size);
+        return ApiResponse.success(responses);
+    }
 
 }

--- a/src/main/java/com/sparta/couponpop/domain/couponevent/dto/cursor/StoreCouponEventsStatisticsCursor.java
+++ b/src/main/java/com/sparta/couponpop/domain/couponevent/dto/cursor/StoreCouponEventsStatisticsCursor.java
@@ -1,0 +1,16 @@
+package com.sparta.couponpop.domain.couponevent.dto.cursor;
+
+public record StoreCouponEventsStatisticsCursor(
+        Long lastStoreId
+) {
+    public static StoreCouponEventsStatisticsCursor first() {
+        return new StoreCouponEventsStatisticsCursor(null);
+    }
+
+    public static StoreCouponEventsStatisticsCursor ofNullable(Long lastStoreId) {
+        return (lastStoreId != null) ?
+                new StoreCouponEventsStatisticsCursor(lastStoreId) :
+                StoreCouponEventsStatisticsCursor.first();
+    }
+
+}

--- a/src/main/java/com/sparta/couponpop/domain/couponevent/dto/response/StoreCouponEventStatisticsResponse.java
+++ b/src/main/java/com/sparta/couponpop/domain/couponevent/dto/response/StoreCouponEventStatisticsResponse.java
@@ -1,0 +1,43 @@
+package com.sparta.couponpop.domain.couponevent.dto.response;
+
+import com.sparta.couponpop.domain.couponevent.dto.cursor.StoreCouponEventsStatisticsCursor;
+import com.sparta.couponpop.domain.couponevent.repository.dto.StoreCouponEventStatisticsProjection;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public record StoreCouponEventStatisticsResponse(
+        List<StoreCouponEventStatisticsProjection> statistics,
+        StoreCouponEventsStatisticsCursor nextCursor,
+        int size,
+        boolean hasNext
+) {
+
+    public static StoreCouponEventStatisticsResponse of(List<StoreCouponEventStatisticsProjection> originalStatistics, int pageSize) {
+        boolean hasNext = originalStatistics.size() > pageSize;
+        List<StoreCouponEventStatisticsProjection> statistics = trimToPageSize(originalStatistics, pageSize);
+        StoreCouponEventsStatisticsCursor cursor = hasNext ? buildNextCursor(statistics) : null;
+        return new StoreCouponEventStatisticsResponse(statistics, cursor, statistics.size(), hasNext);
+    }
+
+    private static List<StoreCouponEventStatisticsProjection> trimToPageSize(List<StoreCouponEventStatisticsProjection> statistics, int pageSize) {
+        if (statistics.size() <= pageSize) {
+            return statistics;
+        }
+
+        List<StoreCouponEventStatisticsProjection> trimmed = new ArrayList<>(statistics);
+        trimmed.remove(trimmed.size() - 1);
+        return trimmed;
+    }
+
+    private static StoreCouponEventsStatisticsCursor buildNextCursor(List<StoreCouponEventStatisticsProjection> statistics) {
+        if (statistics.isEmpty()) {
+            return null;
+        }
+
+        StoreCouponEventStatisticsProjection last = statistics.get(statistics.size() - 1);
+        return new StoreCouponEventsStatisticsCursor(
+                last.storeId()
+        );
+    }
+}

--- a/src/main/java/com/sparta/couponpop/domain/couponevent/repository/CouponEventQueryRepository.java
+++ b/src/main/java/com/sparta/couponpop/domain/couponevent/repository/CouponEventQueryRepository.java
@@ -1,8 +1,10 @@
 package com.sparta.couponpop.domain.couponevent.repository;
 
+import com.sparta.couponpop.domain.couponevent.dto.cursor.StoreCouponEventsCursor;
+import com.sparta.couponpop.domain.couponevent.dto.cursor.StoreCouponEventsStatisticsCursor;
 import com.sparta.couponpop.domain.couponevent.enums.CouponEventStatus;
 import com.sparta.couponpop.domain.couponevent.repository.dto.CouponEventWithUsedCountProjection;
-import com.sparta.couponpop.domain.couponevent.dto.cursor.StoreCouponEventsCursor;
+import com.sparta.couponpop.domain.couponevent.repository.dto.StoreCouponEventStatisticsProjection;
 import com.sparta.couponpop.domain.store.entity.Store;
 
 import java.util.List;
@@ -15,4 +17,6 @@ public interface CouponEventQueryRepository {
             StoreCouponEventsCursor cursor,
             int limit
     );
+
+    List<StoreCouponEventStatisticsProjection> fetchStoreCouponEventStatistics(Long memberId, StoreCouponEventsStatisticsCursor cursor, int limit);
 }

--- a/src/main/java/com/sparta/couponpop/domain/couponevent/repository/CouponEventQueryRepositoryImpl.java
+++ b/src/main/java/com/sparta/couponpop/domain/couponevent/repository/CouponEventQueryRepositoryImpl.java
@@ -1,14 +1,17 @@
 package com.sparta.couponpop.domain.couponevent.repository;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.sparta.couponpop.domain.coupon.entity.QCoupon;
 import com.sparta.couponpop.domain.coupon.enums.CouponStatus;
+import com.sparta.couponpop.domain.couponevent.dto.cursor.StoreCouponEventsCursor;
+import com.sparta.couponpop.domain.couponevent.dto.cursor.StoreCouponEventsStatisticsCursor;
 import com.sparta.couponpop.domain.couponevent.entity.QCouponEvent;
 import com.sparta.couponpop.domain.couponevent.enums.CouponEventStatus;
-import com.sparta.couponpop.domain.couponevent.repository.dto.CouponEventWithUsedCountProjection;
-import com.sparta.couponpop.domain.couponevent.repository.dto.QCouponEventWithUsedCountProjection;
-import com.sparta.couponpop.domain.couponevent.dto.cursor.StoreCouponEventsCursor;
+import com.sparta.couponpop.domain.couponevent.repository.dto.*;
+import com.sparta.couponpop.domain.store.entity.QStore;
 import com.sparta.couponpop.domain.store.entity.Store;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -69,6 +72,40 @@ public class CouponEventQueryRepositoryImpl implements CouponEventQueryRepositor
                 .fetch();
     }
 
+    @Override
+    public List<StoreCouponEventStatisticsProjection> fetchStoreCouponEventStatistics(Long memberId, StoreCouponEventsStatisticsCursor cursor, int limit) {
+        QStore store = QStore.store;
+        QCouponEvent couponEvent = QCouponEvent.couponEvent;
+        QCoupon coupon = QCoupon.coupon;
+
+        NumberExpression<Integer> usedCount = Expressions.numberTemplate(Integer.class,
+                "sum(case when {0}.usedAt is not null then 1 else 0 end)", coupon);
+        return jpaQueryFactory
+                .select(
+                        new QStoreCouponEventStatisticsProjection(
+                                store.id,
+                                store.name,
+                                new QStoreCouponEventStatisticsProjection_CouponStats(
+                                        couponEvent.totalCount.sum(),
+                                        couponEvent.issuedCount.sum(),
+                                        usedCount
+                                ),
+                                couponEvent.eventEndAt.max()
+                        )
+                )
+                .from(store)
+                .leftJoin(couponEvent).on(couponEvent.store.eq(store))
+                .leftJoin(coupon).on(coupon.couponEvent.eq(couponEvent))
+                .where(
+                        store.member.id.eq(memberId),
+                        nextStatisticCondition(store, cursor.lastStoreId())
+                )
+                .groupBy(store.id)
+                .orderBy(store.id.desc())
+                .limit(limit)
+                .fetch();
+    }
+
     private BooleanExpression storeEq(QCouponEvent couponEvent, Store store) {
         if (ObjectUtils.isEmpty(store)) {
             return null;
@@ -104,5 +141,12 @@ public class CouponEventQueryRepositoryImpl implements CouponEventQueryRepositor
                                 .and(couponEvent.eventEndAt.eq(lastEndAt))
                                 .and(couponEvent.id.gt(lastEventId))
                 );
+    }
+
+    private BooleanExpression nextStatisticCondition(QStore store, Long lastStoreId) {
+        if (lastStoreId == null) {
+            return null;
+        }
+        return store.id.lt(lastStoreId);
     }
 }

--- a/src/main/java/com/sparta/couponpop/domain/couponevent/repository/CouponEventQueryRepositoryImpl.java
+++ b/src/main/java/com/sparta/couponpop/domain/couponevent/repository/CouponEventQueryRepositoryImpl.java
@@ -86,9 +86,9 @@ public class CouponEventQueryRepositoryImpl implements CouponEventQueryRepositor
                                 store.id,
                                 store.name,
                                 new QStoreCouponEventStatisticsProjection_CouponStats(
-                                        couponEvent.totalCount.sum(),
-                                        couponEvent.issuedCount.sum(),
-                                        usedCount
+                                        couponEvent.totalCount.sum().coalesce(0),
+                                        couponEvent.issuedCount.sum().coalesce(0),
+                                        usedCount.coalesce(0)
                                 ),
                                 couponEvent.eventEndAt.max()
                         )

--- a/src/main/java/com/sparta/couponpop/domain/couponevent/repository/dto/StoreCouponEventStatisticsProjection.java
+++ b/src/main/java/com/sparta/couponpop/domain/couponevent/repository/dto/StoreCouponEventStatisticsProjection.java
@@ -1,0 +1,34 @@
+package com.sparta.couponpop.domain.couponevent.repository.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+public record StoreCouponEventStatisticsProjection(
+        Long storeId,
+        String storeName,
+        CouponStats couponStats,
+        LocalDateTime lastEventEndAt
+) {
+    @QueryProjection
+    public StoreCouponEventStatisticsProjection {
+    }
+
+    @Getter
+    public static class CouponStats {
+        private final int total;
+        private final int unclaimed;
+        private final int used;
+        private final int unused;
+
+        @QueryProjection
+        public CouponStats(int total, int issuedCount, int usedCount) {
+            this.total = total;
+            this.unclaimed = total - issuedCount;
+            this.used = usedCount;
+            this.unused = issuedCount - usedCount;
+        }
+    }
+
+}

--- a/src/main/java/com/sparta/couponpop/domain/couponevent/service/CouponEventService.java
+++ b/src/main/java/com/sparta/couponpop/domain/couponevent/service/CouponEventService.java
@@ -3,15 +3,18 @@ package com.sparta.couponpop.domain.couponevent.service;
 import com.sparta.couponpop.common.exception.GlobalException;
 import com.sparta.couponpop.domain.coupon.enums.CouponStatus;
 import com.sparta.couponpop.domain.coupon.repository.CouponRepository;
+import com.sparta.couponpop.domain.couponevent.dto.cursor.StoreCouponEventsCursor;
+import com.sparta.couponpop.domain.couponevent.dto.cursor.StoreCouponEventsStatisticsCursor;
 import com.sparta.couponpop.domain.couponevent.dto.request.CreateCouponEventRequest;
 import com.sparta.couponpop.domain.couponevent.dto.response.CouponEventDetailResponse;
 import com.sparta.couponpop.domain.couponevent.dto.response.CreateCouponEventResponse;
 import com.sparta.couponpop.domain.couponevent.dto.response.StoreCouponEventListResponse;
+import com.sparta.couponpop.domain.couponevent.dto.response.StoreCouponEventStatisticsResponse;
 import com.sparta.couponpop.domain.couponevent.entity.CouponEvent;
 import com.sparta.couponpop.domain.couponevent.enums.CouponEventStatus;
 import com.sparta.couponpop.domain.couponevent.exception.CouponEventErrorCode;
 import com.sparta.couponpop.domain.couponevent.repository.CouponEventRepository;
-import com.sparta.couponpop.domain.couponevent.dto.cursor.StoreCouponEventsCursor;
+import com.sparta.couponpop.domain.couponevent.repository.dto.StoreCouponEventStatisticsProjection;
 import com.sparta.couponpop.domain.store.entity.Store;
 import com.sparta.couponpop.domain.store.exception.StoreErrorCode;
 import com.sparta.couponpop.domain.store.repository.StoreRepository;
@@ -92,6 +95,29 @@ public class CouponEventService {
         return StoreCouponEventListResponse.of(store.getId(), store.getName(), couponEventDetailResponses, pageSize);
     }
 
+    /**
+     * 매장별 쿠폰 이벤트 통계 정보를 조회합니다.
+     *
+     * <p>커서 기반 페이지네이션을 지원하며, 주어진 memberId에 해당하는 점주의
+     * 매장 통계를 pageSize 단위로 조회합니다.</p>
+     *
+     * <p>조회 로직:
+     * <ol>
+     *     <li>Repository에서 pageSize + 1 만큼 데이터를 조회하여 다음 페이지 존재 여부 판단</li>
+     *     <li>조회 결과를 {@link StoreCouponEventStatisticsResponse}로 변환</li>
+     * </ol>
+     * </p>
+     *
+     * @param memberId 조회할 점주의 회원 ID
+     * @param cursor 다음 페이지 조회를 위한 커서 정보 (마지막 조회된 storeId 기준)
+     * @param pageSize 한 페이지에 조회할 매장 수
+     * @return {@link StoreCouponEventStatisticsResponse} - 매장별 통계 데이터와 다음 페이지 커서 포함
+     */
+    public StoreCouponEventStatisticsResponse getStoreCouponEventStatistics(Long memberId, StoreCouponEventsStatisticsCursor cursor, int pageSize) {
+        List<StoreCouponEventStatisticsProjection> statistics = couponEventRepository.fetchStoreCouponEventStatistics(memberId, cursor, pageSize + 1);
+        return StoreCouponEventStatisticsResponse.of(statistics, pageSize);
+    }
+
     private void validateEventDuration(LocalDateTime start, LocalDateTime end) {
         // "이벤트 종료 시간은 시작 시간보다 이후여야 합니다."
         if (end.isBefore(start)) {
@@ -105,4 +131,6 @@ public class CouponEventService {
         }
 
     }
+
+
 }

--- a/src/test/java/com/sparta/couponpop/domain/couponevent/controller/CouponEventControllerTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/couponevent/controller/CouponEventControllerTest.java
@@ -8,6 +8,7 @@ import com.sparta.couponpop.common.security.dto.AuthMember;
 import com.sparta.couponpop.domain.couponevent.dto.request.CreateCouponEventRequest;
 import com.sparta.couponpop.domain.couponevent.dto.response.*;
 import com.sparta.couponpop.domain.couponevent.enums.CouponEventStatus;
+import com.sparta.couponpop.domain.couponevent.repository.dto.StoreCouponEventStatisticsProjection;
 import com.sparta.couponpop.domain.couponevent.service.CouponEventService;
 import com.sparta.couponpop.domain.member.enums.MemberType;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,8 +29,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -156,7 +156,7 @@ class CouponEventControllerTest {
                     (long) i,
                     "이벤트 " + i,
                     new EventPeriod(
-                            LocalDateTime.of(2025, 10, 22,4 + i, 0),
+                            LocalDateTime.of(2025, 10, 22, 4 + i, 0),
                             LocalDateTime.of(2025, 10, 22, 5 + i, 0)
                     ),
                     CouponEventStatus.IN_PROGRESS,
@@ -210,5 +210,43 @@ class CouponEventControllerTest {
                 .andExpect(jsonPath("$.data.events.length()").value(5))
                 .andExpect(jsonPath("$.data.hasNext").value(false))
                 .andExpect(jsonPath("$.data.nextCursor").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("매장 별 대시보드 조회 - 성공")
+    void getStoreCouponEventStatistics_withCursor() throws Exception {
+        // given
+        Long lastStoreId = 100L;
+        int size = 2;
+
+        var couponStats = new StoreCouponEventStatisticsProjection.CouponStats(2300, 1840, 1000);
+        var storeStat = new StoreCouponEventStatisticsProjection(
+                101L, "서울 강남점",
+                couponStats,
+                LocalDateTime.of(2025, 10, 21, 23, 59, 59)
+        );
+
+        var responseDto = StoreCouponEventStatisticsResponse.of(
+                List.of(storeStat),
+                size
+        );
+
+        given(couponEventService.getStoreCouponEventStatistics(anyLong(), any(), anyInt()))
+                .willReturn(responseDto);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/owner/stores/events/statistics")
+                        .param("lastStoreId", lastStoreId.toString())
+                        .param("size", String.valueOf(size))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.statistics[0].storeId").value(101))
+                .andExpect(jsonPath("$.data.statistics[0].storeName").value("서울 강남점"))
+                .andExpect(jsonPath("$.data.statistics[0].couponStats.total").value(2300))
+                .andExpect(jsonPath("$.data.statistics[0].couponStats.unclaimed").value(460))
+                .andExpect(jsonPath("$.data.statistics[0].couponStats.used").value(1000))
+                .andExpect(jsonPath("$.data.statistics[0].couponStats.unused").value(840))
+                .andExpect(jsonPath("$.data.nextCursor").isEmpty())
+                .andExpect(jsonPath("$.data.hasNext").value(false));
     }
 }


### PR DESCRIPTION
## 🔗 **연관된 이슈**
- close #34

<br>

## 📝 **작업 내용**

### 응답 예시
```json
{
  "data": [
    {
      "storeId": 101,
      "storeName": "서울 강남점",
      "couponStats": {
        "totalIssuedCount": 2300,   // 전체 발급 쿠폰 수
        "unclaimedCount": 120,      // 미수령 (발급되지 않은)
        "usedCount": 1840,          // 사용 완료
        "unusedCount": 340          // 발급되었지만 아직 사용되지 않은
      },
      "lastEventEndAt": "2025-10-21T23:59:59"
    },
    {
      "storeId": 102,
      "storeName": "부산 해운대점",
      "couponStats": {
        "totalIssuedCount": 1570,
        "unclaimedCount": 95,
        "usedCount": 1395,
        "unusedCount": 80
      },
      "lastEventEndAt": "2025-10-20T23:59:59"
    }
  ],
  "cursor": {
    "next": "2025-10-20T23:59:59_102",
    "hasNext": true
  }
}
```

