### PR TITLE
feat: FCM 알림 전송 후처리 로직 추가

### DIFF
--- a/src/main/java/com/sparta/couponpop/domain/member/entity/MemberFcmToken.java
+++ b/src/main/java/com/sparta/couponpop/domain/member/entity/MemberFcmToken.java
@@ -6,6 +6,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
 
 import java.time.LocalDateTime;
 
@@ -13,6 +14,7 @@ import java.time.LocalDateTime;
 @Table(name = "member_fcm_tokens")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicUpdate
 public class MemberFcmToken extends BaseEntity {
 
     @Id
@@ -72,6 +74,10 @@ public class MemberFcmToken extends BaseEntity {
     public void updateMemberAndDeviceIdentifier(Member member, String deviceIdentifier, LocalDateTime lastUsedAt) {
         this.member = member;
         this.deviceIdentifier = deviceIdentifier;
+        this.lastUsedAt = lastUsedAt;
+    }
+
+    public void updateLastUsedAt(LocalDateTime lastUsedAt) {
         this.lastUsedAt = lastUsedAt;
     }
 

--- a/src/main/java/com/sparta/couponpop/domain/member/repository/MemberFcmTokenRepository.java
+++ b/src/main/java/com/sparta/couponpop/domain/member/repository/MemberFcmTokenRepository.java
@@ -3,9 +3,14 @@ package com.sparta.couponpop.domain.member.repository;
 import com.sparta.couponpop.domain.member.entity.Member;
 import com.sparta.couponpop.domain.member.entity.MemberFcmToken;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface MemberFcmTokenRepository extends JpaRepository<MemberFcmToken, Long> {
 
@@ -16,4 +21,33 @@ public interface MemberFcmTokenRepository extends JpaRepository<MemberFcmToken, 
     List<MemberFcmToken> findByMemberAndNotificationEnabledIsTrue(Member member);
 
     Optional<MemberFcmToken> findByMemberIdAndFcmToken(Long memberId, String fcmToken);
+
+    /**
+     * 다중 FCM 토큰의 lastUsedAt 일괄 업데이트
+     *
+     * @param fcmTokens 토큰 집합
+     * @param now       현재 시간
+     * @return 업데이트된 행 수
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("""
+                UPDATE MemberFcmToken t
+                SET t.lastUsedAt = :now
+                WHERE t.fcmToken IN :fcmTokens
+            """)
+    int updateLastUsedAtByFcmTokenIn(@Param("fcmTokens") Set<String> fcmTokens,
+                                     @Param("now") LocalDateTime now);
+
+    /**
+     * 다중 FCM 토큰의 일괄 삭제
+     *
+     * @param fcmTokens 토큰 집합
+     * @return 삭제된 행 수
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("""
+                DELETE FROM MemberFcmToken t
+                WHERE t.fcmToken IN :fcmTokens
+            """)
+    int deleteByFcmTokenIn(@Param("fcmTokens") Set<String> fcmTokens);
 }

--- a/src/main/java/com/sparta/couponpop/domain/member/service/MemberFcmTokenService.java
+++ b/src/main/java/com/sparta/couponpop/domain/member/service/MemberFcmTokenService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
+import java.util.Set;
 
 @Slf4j
 @Service
@@ -69,5 +70,57 @@ public class MemberFcmTokenService {
                                     member.getId(), request.deviceIdentifier(), request.fcmToken());
                         }
                 );
+    }
+
+    // 단일 토큰 최근 사용 날짜(lastUsedAt) UPDATE
+    @Transactional
+    public void updateLastUsedAt(String fcmToken) {
+        MemberFcmToken memberFcmToken = memberFcmTokenRepository.findByFcmToken(fcmToken)
+                .orElseThrow(() -> new GlobalException(MemberErrorCode.MEMBER_FCM_TOKEN_NOT_FOUND));
+
+        memberFcmToken.updateLastUsedAt(LocalDateTime.now());
+    }
+
+    // 단일 토큰 삭제
+    @Transactional
+    public void deleteToken(String fcmToken) {
+        MemberFcmToken memberFcmToken = memberFcmTokenRepository.findByFcmToken(fcmToken)
+                .orElseThrow(() -> new GlobalException(MemberErrorCode.MEMBER_FCM_TOKEN_NOT_FOUND));
+
+        memberFcmTokenRepository.delete(memberFcmToken);
+    }
+
+    /**
+     * FCM 전송 결과에 따라 성공 토큰은 업데이트, 실패 토큰은 삭제를 원자적으로 처리한다.
+     */
+    @Transactional
+    public void updateTokensAfterSend(Set<String> successTokens, Set<String> failureTokens) {
+        LocalDateTime now = LocalDateTime.now();
+
+        if (successTokens != null && !successTokens.isEmpty()) {
+            updateLastUsedAtInternal(successTokens, now);
+        }
+
+        if (failureTokens != null && !failureTokens.isEmpty()) {
+            deleteTokensInternal(failureTokens);
+        }
+    }
+
+    private void updateLastUsedAtInternal(Set<String> fcmTokens, LocalDateTime now) {
+        if (fcmTokens == null || fcmTokens.isEmpty()) {
+            return;
+        }
+
+        int updatedCount = memberFcmTokenRepository.updateLastUsedAtByFcmTokenIn(fcmTokens, now);
+        log.info("FCM 성공 토큰 {}개 최근 사용 날짜 업데이트 완료", updatedCount);
+    }
+
+    private void deleteTokensInternal(Set<String> fcmTokens) {
+        if (fcmTokens == null || fcmTokens.isEmpty()) {
+            return;
+        }
+
+        int deletedCount = memberFcmTokenRepository.deleteByFcmTokenIn(fcmTokens);
+        log.info("FCM 실패 토큰 {}개 삭제 완료", deletedCount);
     }
 }

--- a/src/main/java/com/sparta/couponpop/domain/notification/service/FcmSendService.java
+++ b/src/main/java/com/sparta/couponpop/domain/notification/service/FcmSendService.java
@@ -1,6 +1,7 @@
 package com.sparta.couponpop.domain.notification.service;
 
 import com.google.firebase.messaging.*;
+import com.sparta.couponpop.domain.member.service.MemberFcmTokenService;
 import com.sparta.couponpop.domain.notification.factory.FcmMessageFactory;
 import com.sparta.couponpop.domain.notificationhistory.dto.payload.NotificationHistoryPayload;
 import com.sparta.couponpop.domain.notificationhistory.enums.NotificationHistoryStatus;
@@ -12,7 +13,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Slf4j
 @Service
@@ -25,9 +28,20 @@ public class FcmSendService {
 
     private final FcmMessageFactory fcmMessageFactory;
     private final NotificationHistoryService notificationHistoryService;
+    private final MemberFcmTokenService memberFcmTokenService;
 
-    // TODO: 발송된 토큰의 lastUsedAt 업데이트 로직 추가 예정
+    /**
+     * 단일 기기 푸시 알림 전송
+     *
+     * @param memberId 회원 ID
+     * @param token    FCM 토큰
+     * @param title    알림 제목
+     * @param body     알림 내용
+     * @throws FirebaseMessagingException FCM 전송 중 오류 발생 시 예외 처리
+     */
     public void sendNotification(Long memberId, String token, String title, String body) throws FirebaseMessagingException {
+        log.info("단일 기기 푸시 알림 전송 시작: memberId={}, token={}", memberId, token);
+
         if (!StringUtils.hasText(token)) {
             log.info("FCM 전송 토큰이 유효하지 않아 전송을 건너뜁니다.");
             return;
@@ -39,32 +53,41 @@ public class FcmSendService {
         Message message = fcmMessageFactory.createMessage(token, title, body);
         try {
             FirebaseMessaging.getInstance().send(message);
+
+            memberFcmTokenService.updateLastUsedAt(token);
         } catch (FirebaseMessagingException e) {
             log.error("FCM 전송 중 오류 발생: {}", e.getMessage());
 
             status = NotificationHistoryStatus.FAILURE;
             failureReason = e.getMessage();
 
+            memberFcmTokenService.deleteToken(token);
+
             throw e; // 예외 재던지기
         } finally {
             NotificationHistoryPayload notificationHistoryPayload = NotificationHistoryPayload.of(memberId, NOTIFICATION_HISTORY_TYPE, title, body, status, failureReason);
             notificationHistoryService.createNotificationHistory(notificationHistoryPayload);
         }
-
-        // TODO: 성공 토큰 lastUsedAt 업데이트
-        // TODO: 실패 토큰 삭제 처리
     }
 
-    // TODO: 발송된 토큰의 lastUsedAt 업데이트 로직 추가 예정
+    /**
+     * 멤버별 다중 기기 푸시 알림 전송
+     *
+     * @param memberId 멤버 ID
+     * @param tokens   FCM 토큰 리스트
+     * @param title    알림 제목
+     * @param body     알림 내용
+     * @throws FirebaseMessagingException FCM 전송 중 오류 발생 시 예외 처리
+     */
     public void sendNotification(Long memberId, List<String> tokens, String title, String body) throws FirebaseMessagingException {
+        log.info("멤버별 다중 기기 푸시 알림 전송 시작: memberId={}, tokensCount={}", memberId, tokens.size());
+
         if (tokens == null || tokens.isEmpty()) {
             log.info("FCM 전송 토큰이 비어 있어 전송을 건너뜁니다.");
             return;
         }
 
-        List<NotificationHistoryPayload> historyPayloads = new ArrayList<>();
-        List<List<SendResponse>> allResponses = new ArrayList<>();
-
+        List<List<SendResponse>> totalResponses = new ArrayList<>();
         for (int start = 0; start < tokens.size(); start += FCM_MULTICAST_LIMIT) {
             int end = Math.min(start + FCM_MULTICAST_LIMIT, tokens.size());
             List<String> batch = tokens.subList(start, end);
@@ -75,14 +98,21 @@ public class FcmSendService {
             BatchResponse response = FirebaseMessaging.getInstance().sendEachForMulticast(message);
             log.info("[FCM 다건 전송 결과] 성공={} 실패={}", response.getSuccessCount(), response.getFailureCount());
 
-            allResponses.add(response.getResponses());
-
-            // TODO: 성공 토큰 lastUsedAt 업데이트
-            // TODO: 실패 토큰 삭제 처리
+            totalResponses.add(response.getResponses());
         }
 
-        // 알림 이력 생성
-        for (List<SendResponse> responses : allResponses) {
+        createHistoryAfterMulticastSend(totalResponses, memberId, title, body);
+        updateTokensAfterMulticastSend(totalResponses, tokens);
+    }
+
+    // 다중 기기 푸시 후 알림 히스토리 생성
+    private void createHistoryAfterMulticastSend(List<List<SendResponse>> totalResponses,
+                                                 Long memberId,
+                                                 String title,
+                                                 String body) {
+        List<NotificationHistoryPayload> historyPayloads = new ArrayList<>();
+
+        for (List<SendResponse> responses : totalResponses) {
             for (SendResponse sendResponse : responses) {
                 NotificationHistoryStatus status;
                 String failureReason = null;
@@ -107,5 +137,30 @@ public class FcmSendService {
         }
 
         notificationHistoryService.bulkInsertNotificationHistories(historyPayloads);
+    }
+
+    // 다중 기기 푸시 후 토큰 업데이트
+    private void updateTokensAfterMulticastSend(List<List<SendResponse>> totalResponses,
+                                                List<String> tokens) {
+        Set<String> successTokens = new HashSet<>();
+        Set<String> failureTokens = new HashSet<>();
+
+        // 알림 히스토리 생성 및 성공/실패 토큰 처리
+        for (int batchIndex = 0; batchIndex < totalResponses.size(); batchIndex++) {
+            List<SendResponse> responses = totalResponses.get(batchIndex);
+
+            for (int i = 0; i < responses.size(); i++) {
+                int tokenIndex = batchIndex * FCM_MULTICAST_LIMIT + i;
+                SendResponse sendResponse = responses.get(i);
+
+                if (sendResponse.isSuccessful()) {
+                    successTokens.add(tokens.get(tokenIndex));
+                } else {
+                    failureTokens.add(tokens.get(tokenIndex));
+                }
+            }
+        }
+
+        memberFcmTokenService.updateTokensAfterSend(successTokens, failureTokens);
     }
 }

--- a/src/test/java/com/sparta/couponpop/domain/member/service/MemberFcmTokenServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/member/service/MemberFcmTokenServiceTest.java
@@ -20,14 +20,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.eq;
 
 @ExtendWith(MockitoExtension.class)
 class MemberFcmTokenServiceTest {
@@ -153,6 +154,116 @@ class MemberFcmTokenServiceTest {
             then(memberFcmTokenRepository).should(never()).findByFcmToken(anyString());
             then(memberFcmTokenRepository).should(never()).findByMemberAndDeviceIdentifier(any(Member.class), anyString());
             then(memberFcmTokenRepository).should(never()).save(any(MemberFcmToken.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("updateLastUsedAt")
+    class UpdateLastUsedAt {
+
+        @Test
+        @DisplayName("토큰이 존재하면 최근 사용 시간을 갱신한다")
+        void updateLastUsedAt_success_tokenExists() {
+            // given
+            String fcmToken = "existing-token";
+            MemberFcmToken memberFcmToken = mock(MemberFcmToken.class);
+            given(memberFcmTokenRepository.findByFcmToken(fcmToken)).willReturn(Optional.of(memberFcmToken));
+
+            // when
+            memberFcmTokenService.updateLastUsedAt(fcmToken);
+
+            // then
+            then(memberFcmTokenRepository).should(times(1)).findByFcmToken(fcmToken);
+            then(memberFcmToken).should(times(1)).updateLastUsedAt(any(LocalDateTime.class));
+        }
+
+        @Test
+        @DisplayName("토큰이 없으면 예외를 던진다")
+        void updateLastUsedAt_fail_tokenNotFound() {
+            // given
+            String fcmToken = "missing-token";
+            given(memberFcmTokenRepository.findByFcmToken(fcmToken)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> memberFcmTokenService.updateLastUsedAt(fcmToken))
+                    .isInstanceOf(GlobalException.class)
+                    .hasMessage(MemberErrorCode.MEMBER_FCM_TOKEN_NOT_FOUND.getMessage());
+
+            then(memberFcmTokenRepository).should(times(1)).findByFcmToken(fcmToken);
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteToken")
+    class DeleteToken {
+
+        @Test
+        @DisplayName("토큰이 존재하면 삭제한다")
+        void deleteToken_success_tokenExists() {
+            // given
+            String fcmToken = "removable-token";
+            MemberFcmToken memberFcmToken = mock(MemberFcmToken.class);
+            given(memberFcmTokenRepository.findByFcmToken(fcmToken)).willReturn(Optional.of(memberFcmToken));
+
+            // when
+            memberFcmTokenService.deleteToken(fcmToken);
+
+            // then
+            then(memberFcmTokenRepository).should(times(1)).findByFcmToken(fcmToken);
+            then(memberFcmTokenRepository).should(times(1)).delete(memberFcmToken);
+        }
+
+        @Test
+        @DisplayName("토큰이 없으면 예외를 던진다")
+        void deleteToken_fail_tokenNotFound() {
+            // given
+            String fcmToken = "invalid-token";
+            given(memberFcmTokenRepository.findByFcmToken(fcmToken)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> memberFcmTokenService.deleteToken(fcmToken))
+                    .isInstanceOf(GlobalException.class)
+                    .hasMessage(MemberErrorCode.MEMBER_FCM_TOKEN_NOT_FOUND.getMessage());
+
+            then(memberFcmTokenRepository).should(times(1)).findByFcmToken(fcmToken);
+            then(memberFcmTokenRepository).should(never()).delete(any(MemberFcmToken.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("updateTokensAfterSend")
+    class UpdateTokensAfterSend {
+
+        @Test
+        @DisplayName("성공 토큰은 최근 사용 시간을 갱신하고 실패 토큰은 삭제한다")
+        void updateTokensAfterSend_success_updatesAndDeletes() {
+            // given
+            Set<String> successTokens = Set.of("success-1", "success-2");
+            Set<String> failureTokens = Set.of("failure-1");
+            given(memberFcmTokenRepository.updateLastUsedAtByFcmTokenIn(anySet(), any(LocalDateTime.class))).willReturn(successTokens.size());
+            given(memberFcmTokenRepository.deleteByFcmTokenIn(failureTokens)).willReturn(failureTokens.size());
+
+            // when
+            memberFcmTokenService.updateTokensAfterSend(successTokens, failureTokens);
+
+            // then
+            then(memberFcmTokenRepository).should(times(1)).updateLastUsedAtByFcmTokenIn(eq(successTokens), any(LocalDateTime.class));
+            then(memberFcmTokenRepository).should(times(1)).deleteByFcmTokenIn(eq(failureTokens));
+        }
+
+        @Test
+        @DisplayName("전달된 토큰이 없으면 아무 작업도 수행하지 않는다")
+        void updateTokensAfterSend_skip_whenTokensEmpty() {
+            // given
+            Set<String> successTokens = Set.of();
+            Set<String> failureTokens = Set.of();
+
+            // when
+            memberFcmTokenService.updateTokensAfterSend(successTokens, failureTokens);
+
+            // then
+            then(memberFcmTokenRepository).should(never()).updateLastUsedAtByFcmTokenIn(anySet(), any(LocalDateTime.class));
+            then(memberFcmTokenRepository).should(never()).deleteByFcmTokenIn(anySet());
         }
     }
 }

--- a/src/test/java/com/sparta/couponpop/domain/notification/service/FcmSendServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/notification/service/FcmSendServiceTest.java
@@ -1,6 +1,7 @@
 package com.sparta.couponpop.domain.notification.service;
 
 import com.google.firebase.messaging.*;
+import com.sparta.couponpop.domain.member.service.MemberFcmTokenService;
 import com.sparta.couponpop.domain.notification.factory.FcmMessageFactory;
 import com.sparta.couponpop.domain.notificationhistory.dto.payload.NotificationHistoryPayload;
 import com.sparta.couponpop.domain.notificationhistory.enums.NotificationHistoryStatus;
@@ -16,16 +17,14 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.lang.reflect.Field;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.BDDMockito.willAnswer;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -37,206 +36,257 @@ class FcmSendServiceTest {
     @Mock
     private NotificationHistoryService notificationHistoryService;
 
+    @Mock
+    private MemberFcmTokenService memberFcmTokenService;
+
     @InjectMocks
     private FcmSendService fcmSendService;
 
     @Nested
-    @DisplayName("FCM 알림 발송")
-    class SendNotification {
+    @DisplayName("단일 기기 푸시 알림 전송")
+    class SendNotificationWithSingleToken {
+
         @Test
-        @DisplayName("단일 토큰 전송 시 메시지를 생성한다")
-        void sendNotification_success_singleToken() throws FirebaseMessagingException {
+        @DisplayName("전송 성공 시 토큰을 갱신하고 히스토리를 성공으로 저장한다")
+        void sendNotification_success() throws FirebaseMessagingException {
             // given
             Long memberId = 1L;
-            String token = "test-token";
-            String title = "알림 제목";
-            String body = "알림 내용";
-            given(fcmMessageFactory.createMessage(anyString(), anyString(), anyString()))
-                    .willAnswer(invocation -> {
-                        String requestToken = invocation.getArgument(0, String.class);
-                        String requestTitle = invocation.getArgument(1, String.class);
-                        String requestBody = invocation.getArgument(2, String.class);
-                        return Message.builder()
-                                .setToken(requestToken)
-                                .setNotification(Notification.builder()
-                                        .setTitle(requestTitle)
-                                        .setBody(requestBody)
-                                        .build())
-                                .putData("title", requestTitle)
-                                .putData("body", requestBody)
-                                .build();
-                    });
+            String token = "success-token";
+            String title = "제목";
+            String body = "본문";
+
+            Message message = Message.builder().setToken(token).build();
+            when(fcmMessageFactory.createMessage(token, title, body)).thenReturn(message);
 
             FirebaseMessaging firebaseMessaging = mock(FirebaseMessaging.class);
-            given(firebaseMessaging.send(any(Message.class))).willReturn("mock-message-id");
-            NotificationHistoryPayload expectedPayload = NotificationHistoryPayload.of(
-                    memberId,
-                    NotificationHistoryType.FCM,
-                    title,
-                    body,
-                    NotificationHistoryStatus.SUCCESS,
-                    null
-            );
 
-            try (MockedStatic<FirebaseMessaging> mockedStatic = mockStatic(FirebaseMessaging.class)) {
-                mockedStatic.when(FirebaseMessaging::getInstance).thenReturn(firebaseMessaging);
+            try (MockedStatic<FirebaseMessaging> mockedFirebaseMessaging = mockStatic(FirebaseMessaging.class)) {
+                mockedFirebaseMessaging.when(FirebaseMessaging::getInstance).thenReturn(firebaseMessaging);
 
                 // when
                 fcmSendService.sendNotification(memberId, token, title, body);
 
                 // then
-                ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
-                then(firebaseMessaging).should(times(1)).send(messageCaptor.capture());
-                Message sentMessage = messageCaptor.getValue();
-
-                assertThat(extractToken(sentMessage)).isEqualTo(token);
-                Notification notification = extractNotification(sentMessage);
-                assertThat(extractNotificationValue(notification, "title")).isEqualTo(title);
-                assertThat(extractNotificationValue(notification, "body")).isEqualTo(body);
-                then(notificationHistoryService).should().createNotificationHistory(expectedPayload);
+                verify(firebaseMessaging).send(message);
+                verify(memberFcmTokenService).updateLastUsedAt(token);
+                verify(notificationHistoryService).createNotificationHistory(NotificationHistoryPayload.of(
+                        memberId,
+                        NotificationHistoryType.FCM,
+                        title,
+                        body,
+                        NotificationHistoryStatus.SUCCESS,
+                        null
+                ));
             }
         }
 
         @Test
-        @DisplayName("토큰이 비어 있으면 FCM 전송을 수행하지 않는다")
-        void sendNotification_skipSend_tokensEmpty() throws FirebaseMessagingException {
+        @DisplayName("FCM 예외가 발생하면 토큰을 삭제하고 실패 히스토리를 저장한다")
+        void sendNotification_failure() throws FirebaseMessagingException {
             // given
-                Long memberId = 1L;
-                List<String> emptyTokens = Collections.emptyList();
+            Long memberId = 1L;
+            String token = "failure-token";
+            String title = "제목";
+            String body = "본문";
 
-            try (MockedStatic<FirebaseMessaging> mockedStatic = mockStatic(FirebaseMessaging.class)) {
+            Message message = Message.builder().setToken(token).build();
+            when(fcmMessageFactory.createMessage(token, title, body)).thenReturn(message);
+
+            FirebaseMessaging firebaseMessaging = mock(FirebaseMessaging.class);
+
+            FirebaseMessagingException messagingException = mock(FirebaseMessagingException.class);
+            when(messagingException.getMessage()).thenReturn("전송 실패");
+            when(firebaseMessaging.send(message)).thenThrow(messagingException);
+
+            try (MockedStatic<FirebaseMessaging> mockedFirebaseMessaging = mockStatic(FirebaseMessaging.class)) {
+                mockedFirebaseMessaging.when(FirebaseMessaging::getInstance).thenReturn(firebaseMessaging);
+
                 // when
-                fcmSendService.sendNotification(memberId, emptyTokens, "제목", "본문");
+                try {
+                    fcmSendService.sendNotification(memberId, token, title, body);
+                } catch (FirebaseMessagingException ignored) {
+                    // 예외는 상위로 전달된다.
+                }
 
                 // then
-                mockedStatic.verifyNoInteractions();
-                verifyNoInteractions(fcmMessageFactory);
+                verify(firebaseMessaging).send(message);
+                verify(memberFcmTokenService).deleteToken(token);
+                verify(notificationHistoryService).createNotificationHistory(NotificationHistoryPayload.of(
+                        memberId,
+                        NotificationHistoryType.FCM,
+                        title,
+                        body,
+                        NotificationHistoryStatus.FAILURE,
+                        "전송 실패"
+                ));
             }
         }
 
         @Test
-        @DisplayName("토큰이 500개 초과 시 500개 단위로 배치 전송한다")
+        @DisplayName("토큰이 비어 있으면 전송을 건너뛴다")
+        void sendNotification_skip_tokenEmpty() throws FirebaseMessagingException {
+            // given
+            Long memberId = 1L;
+            String token = "";
+
+            // when
+            fcmSendService.sendNotification(memberId, token, "제목", "본문");
+
+            // then
+            verifyNoInteractions(fcmMessageFactory, memberFcmTokenService, notificationHistoryService);
+        }
+    }
+
+    @Nested
+    @DisplayName("다중 기기 푸시 알림 전송")
+    class SendNotificationWithMultipleTokens {
+
+        @Test
+        @DisplayName("FCM 응답에 따라 성공 토큰을 갱신하고 실패 토큰을 정리한다")
+        void sendNotification_success() throws FirebaseMessagingException {
+            // given
+            Long memberId = 1L;
+            List<String> tokens = List.of("token-success", "token-failure");
+            String title = "제목";
+            String body = "본문";
+
+            MulticastMessage multicastMessage = MulticastMessage.builder()
+                    .addAllTokens(tokens)
+                    .build();
+            when(fcmMessageFactory.createMulticastMessage(anyList(), eq(title), eq(body))).thenReturn(multicastMessage);
+
+            SendResponse successResponse = mock(SendResponse.class);
+            when(successResponse.isSuccessful()).thenReturn(true);
+
+            SendResponse failureResponse = mock(SendResponse.class);
+            when(failureResponse.isSuccessful()).thenReturn(false);
+
+            FirebaseMessagingException messagingException = mock(FirebaseMessagingException.class);
+            when(messagingException.getMessage()).thenReturn("FCM 실패");
+            when(failureResponse.getException()).thenReturn(messagingException);
+
+            BatchResponse batchResponse = mock(BatchResponse.class);
+            when(batchResponse.getSuccessCount()).thenReturn(1);
+            when(batchResponse.getFailureCount()).thenReturn(1);
+            when(batchResponse.getResponses()).thenReturn(List.of(successResponse, failureResponse));
+
+            FirebaseMessaging firebaseMessaging = mock(FirebaseMessaging.class);
+
+            try (MockedStatic<FirebaseMessaging> mockedFirebaseMessaging = mockStatic(FirebaseMessaging.class)) {
+                mockedFirebaseMessaging.when(FirebaseMessaging::getInstance).thenReturn(firebaseMessaging);
+                when(firebaseMessaging.sendEachForMulticast(multicastMessage)).thenReturn(batchResponse);
+
+                // when
+                fcmSendService.sendNotification(memberId, tokens, title, body);
+
+                // then
+                @SuppressWarnings("unchecked")
+                ArgumentCaptor<Set<String>> successCaptor = ArgumentCaptor.forClass(Set.class);
+                @SuppressWarnings("unchecked")
+                ArgumentCaptor<Set<String>> failureCaptor = ArgumentCaptor.forClass(Set.class);
+                verify(memberFcmTokenService).updateTokensAfterSend(successCaptor.capture(), failureCaptor.capture());
+
+                assertThat(successCaptor.getValue()).containsExactlyInAnyOrder("token-success");
+                assertThat(failureCaptor.getValue()).containsExactlyInAnyOrder("token-failure");
+
+                @SuppressWarnings("unchecked")
+                ArgumentCaptor<List<NotificationHistoryPayload>> historyCaptor = ArgumentCaptor.forClass(List.class);
+                verify(notificationHistoryService).bulkInsertNotificationHistories(historyCaptor.capture());
+
+                List<NotificationHistoryPayload> payloads = historyCaptor.getValue();
+                assertThat(payloads).hasSize(2);
+                assertThat(payloads.get(0).status()).isEqualTo(NotificationHistoryStatus.SUCCESS);
+                assertThat(payloads.get(1).status()).isEqualTo(NotificationHistoryStatus.FAILURE);
+                assertThat(payloads.get(1).failureReason()).isEqualTo("FCM 실패");
+
+                verify(firebaseMessaging).sendEachForMulticast(multicastMessage);
+            }
+        }
+
+        @Test
+        @DisplayName("토큰이 비어 있으면 전송을 건너뛴다")
+        void sendNotification_skip_tokensEmpty() throws FirebaseMessagingException {
+            // given
+            Long memberId = 1L;
+            List<String> tokens = Collections.emptyList();
+
+            // when
+            fcmSendService.sendNotification(memberId, tokens, "제목", "본문");
+
+            // then
+            verifyNoInteractions(fcmMessageFactory, memberFcmTokenService, notificationHistoryService);
+        }
+
+        @Test
+        @DisplayName("토큰 개수가 500개가 초과되면 배치로 나누어 전송한다")
         void sendNotification_success_tokensExceedLimit() throws FirebaseMessagingException {
             // given
-            Long memberId = 2L;
-            List<String> tokens = new ArrayList<>();
-            for (int i = 0; i < 750; i++) {
-                tokens.add("token-" + i);
-            }
-            given(fcmMessageFactory.createMulticastMessage(anyList(), anyString(), anyString()))
-                    .willAnswer(invocation -> {
-                        @SuppressWarnings("unchecked")
-                        List<String> requestTokens = new ArrayList<>((List<String>) invocation.getArgument(0, List.class));
-                        String requestTitle = invocation.getArgument(1, String.class);
-                        String requestBody = invocation.getArgument(2, String.class);
-                        return buildMessage(requestTokens, requestTitle, requestBody);
+            Long memberId = 1L;
+            List<String> tokens = IntStream.range(0, 600)
+                    .mapToObj(i -> "token-" + i)
+                    .toList();
+            String title = "제목";
+            String body = "본문";
+
+            MulticastMessage firstBatchMessage = mock(MulticastMessage.class);
+            MulticastMessage secondBatchMessage = mock(MulticastMessage.class);
+            when(fcmMessageFactory.createMulticastMessage(anyList(), eq(title), eq(body)))
+                    .thenAnswer(invocation -> {
+                        List<String> batchTokens = invocation.getArgument(0);
+                        if (batchTokens.size() == 500) {
+                            return firstBatchMessage;
+                        }
+                        if (batchTokens.size() == 100) {
+                            return secondBatchMessage;
+                        }
+                        throw new IllegalArgumentException("알 수 없는 배치 크기: " + batchTokens.size());
                     });
+
+            SendResponse successResponse = mock(SendResponse.class);
+            when(successResponse.isSuccessful()).thenReturn(true);
+
+            BatchResponse firstBatchResponse = mock(BatchResponse.class);
+            when(firstBatchResponse.getSuccessCount()).thenReturn(500);
+            when(firstBatchResponse.getFailureCount()).thenReturn(0);
+            when(firstBatchResponse.getResponses()).thenReturn(Collections.nCopies(500, successResponse));
+
+            BatchResponse secondBatchResponse = mock(BatchResponse.class);
+            when(secondBatchResponse.getSuccessCount()).thenReturn(100);
+            when(secondBatchResponse.getFailureCount()).thenReturn(0);
+            when(secondBatchResponse.getResponses()).thenReturn(Collections.nCopies(100, successResponse));
+
             FirebaseMessaging firebaseMessaging = mock(FirebaseMessaging.class);
-            willAnswer(invocation -> {
-                MulticastMessage multicastMessage = invocation.getArgument(0, MulticastMessage.class);
-                List<String> requestTokens = extractTokens(multicastMessage);
 
-                BatchResponse dynamicResponse = mock(BatchResponse.class);
-                List<SendResponse> sendResponses = requestTokens.stream()
-                        .map(token -> {
-                            SendResponse sendResponse = mock(SendResponse.class);
-                            given(sendResponse.isSuccessful()).willReturn(true);
-                            return sendResponse;
-                        })
-                        .toList();
-
-                given(dynamicResponse.getSuccessCount()).willReturn(requestTokens.size());
-                given(dynamicResponse.getFailureCount()).willReturn(0);
-                given(dynamicResponse.getResponses()).willReturn(sendResponses);
-                return dynamicResponse;
-            }).given(firebaseMessaging).sendEachForMulticast(any(MulticastMessage.class));
-
-            try (MockedStatic<FirebaseMessaging> mockedStatic = mockStatic(FirebaseMessaging.class)) {
-                mockedStatic.when(FirebaseMessaging::getInstance).thenReturn(firebaseMessaging);
+            try (MockedStatic<FirebaseMessaging> mockedFirebaseMessaging = mockStatic(FirebaseMessaging.class)) {
+                mockedFirebaseMessaging.when(FirebaseMessaging::getInstance).thenReturn(firebaseMessaging);
+                when(firebaseMessaging.sendEachForMulticast(firstBatchMessage)).thenReturn(firstBatchResponse);
+                when(firebaseMessaging.sendEachForMulticast(secondBatchMessage)).thenReturn(secondBatchResponse);
 
                 // when
-                fcmSendService.sendNotification(memberId, tokens, "배치 제목", "배치 본문");
+                fcmSendService.sendNotification(memberId, tokens, title, body);
 
                 // then
-                ArgumentCaptor<MulticastMessage> messageCaptor = ArgumentCaptor.forClass(MulticastMessage.class);
-                then(firebaseMessaging).should(times(2)).sendEachForMulticast(messageCaptor.capture());
-                List<MulticastMessage> capturedMessages = messageCaptor.getAllValues();
+                verify(firebaseMessaging, times(1)).sendEachForMulticast(firstBatchMessage);
+                verify(firebaseMessaging, times(1)).sendEachForMulticast(secondBatchMessage);
 
-                assertThat(capturedMessages).hasSize(2);
-                assertThat(extractTokens(capturedMessages.get(0))).hasSize(500);
-                assertThat(extractTokens(capturedMessages.get(1))).hasSize(250);
-                then(fcmMessageFactory).should(times(2)).createMulticastMessage(anyList(), eq("배치 제목"), eq("배치 본문"));
-                then(notificationHistoryService).should().bulkInsertNotificationHistories(argThat(payloads -> {
-                    assertThat(payloads).hasSize(tokens.size());
-                    assertThat(payloads)
-                            .allMatch(payload -> payload.memberId().equals(memberId)
-                                    && payload.type() == NotificationHistoryType.FCM
-                                    && payload.title().equals("배치 제목")
-                                    && payload.body().equals("배치 본문")
-                                    && payload.status() == NotificationHistoryStatus.SUCCESS);
-                    return true;
-                }));
-            }
-        }
-
-        private MulticastMessage buildMessage(List<String> tokens,
-                                              String title,
-                                              String body) {
-            // 팩토리가 생성하는 메시지를 모사해 빌더 기반 구성을 재현한다.
-            return MulticastMessage.builder()
-                    .addAllTokens(tokens)
-                    .setNotification(Notification.builder()
-                            .setTitle(title)
-                            .setBody(body)
-                            .build())
-                    .putData("title", title)
-                    .putData("body", body)
-                    .build();
-        }
-
-        private List<String> extractTokens(MulticastMessage message) {
-            // MulticastMessage는 Getter를 제공하지 않아 리플렉션으로 토큰 수를 검증한다.
-            try {
-                Field field = MulticastMessage.class.getDeclaredField("tokens");
-                field.setAccessible(true);
                 @SuppressWarnings("unchecked")
-                List<String> tokens = (List<String>) field.get(message);
-                return tokens;
-            } catch (NoSuchFieldException | IllegalAccessException e) {
-                throw new IllegalStateException("토큰 정보를 확인할 수 없습니다.", e);
-            }
-        }
+                ArgumentCaptor<Set<String>> successCaptor = ArgumentCaptor.forClass(Set.class);
+                @SuppressWarnings("unchecked")
+                ArgumentCaptor<Set<String>> failureCaptor = ArgumentCaptor.forClass(Set.class);
+                verify(memberFcmTokenService).updateTokensAfterSend(successCaptor.capture(), failureCaptor.capture());
 
-        private String extractToken(Message message) {
-            // Message는 Getter를 제공하지 않아 리플렉션으로 토큰을 검증한다.
-            try {
-                Field field = Message.class.getDeclaredField("token");
-                field.setAccessible(true);
-                return (String) field.get(message);
-            } catch (NoSuchFieldException | IllegalAccessException e) {
-                throw new IllegalStateException("토큰 정보를 확인할 수 없습니다.", e);
-            }
-        }
+                assertThat(successCaptor.getValue()).containsExactlyInAnyOrderElementsOf(tokens);
+                assertThat(failureCaptor.getValue()).isEmpty();
 
-        private Notification extractNotification(Message message) {
-            // 알림 객체 역시 리플렉션으로 확인한다.
-            try {
-                Field field = Message.class.getDeclaredField("notification");
-                field.setAccessible(true);
-                return (Notification) field.get(message);
-            } catch (NoSuchFieldException | IllegalAccessException e) {
-                throw new IllegalStateException("알림 정보를 확인할 수 없습니다.", e);
-            }
-        }
+                @SuppressWarnings("unchecked")
+                ArgumentCaptor<List<NotificationHistoryPayload>> historyCaptor = ArgumentCaptor.forClass(List.class);
+                verify(notificationHistoryService).bulkInsertNotificationHistories(historyCaptor.capture());
 
-        private String extractNotificationValue(Notification notification, String fieldName) {
-            // Notification은 비공개 필드만 노출하므로 리플렉션으로 값을 읽는다.
-            try {
-                Field field = Notification.class.getDeclaredField(fieldName);
-                field.setAccessible(true);
-                return (String) field.get(notification);
-            } catch (NoSuchFieldException | IllegalAccessException e) {
-                throw new IllegalStateException("알림 속성을 확인할 수 없습니다.", e);
+                List<NotificationHistoryPayload> payloads = historyCaptor.getValue();
+                assertThat(payloads).hasSize(tokens.size());
+                assertThat(payloads)
+                        .allMatch(payload -> payload.status() == NotificationHistoryStatus.SUCCESS
+                                && payload.failureReason() == null);
             }
         }
     }


### PR DESCRIPTION
## 🔗 **연관된 이슈**
> close #이슈번호
- close #109 

<br>

## 📝 **작업 내용**

FCM 알림 발송 후 성공한 토큰 혹은 토큰들의 `last_used_at` 필드 갱신 / 실패한 토큰 혹은 토큰들 삭제

### 다중 토큰
- `@Modifying` 어노테이션 활용하여 bulk update/delete
- 데이터 불일치를 방지하기 위해 `@Modifying(clearAutomatically = true)` 옵션 추가
   - 쿼리 실행 후 1차 캐시 자동 초기화 (EntityManager.clear())
   - 현재는 서비스에서 조회/1차 캐싱이 없기 때문에 필요없지만 방어적으로 붙임

<br>

## 📸 **스크린샷 (선택)**

<br>
