### PR TITLE
refactor: `MemberFcmToken` 도메인을 `FcmToken` 으로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ flyway {
     locations = ['filesystem:src/main/resources/db/migration']
     baselineOnMigrate = true
     baselineVersion = 1
-    cleanDisabled = false
+    cleanDisabled = true
 }
 
 jacoco {

--- a/src/main/java/com/sparta/couponpop/common/fcm/service/FcmSendService.java
+++ b/src/main/java/com/sparta/couponpop/common/fcm/service/FcmSendService.java
@@ -6,7 +6,7 @@ import com.google.api.core.ApiFutures;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.Message;
 import com.sparta.couponpop.common.fcm.factory.FcmMessageFactory;
-import com.sparta.couponpop.domain.member.service.MemberFcmTokenService;
+import com.sparta.couponpop.domain.fcmtoken.service.FcmTokenService;
 import com.sparta.couponpop.domain.notificationhistory.dto.payload.NotificationHistoryPayload;
 import com.sparta.couponpop.domain.notificationhistory.enums.NotificationHistoryStatus;
 import com.sparta.couponpop.domain.notificationhistory.enums.NotificationHistoryType;
@@ -31,7 +31,7 @@ public class FcmSendService {
 
     private final FcmMessageFactory fcmMessageFactory;
     private final NotificationHistoryService notificationHistoryService;
-    private final MemberFcmTokenService memberFcmTokenService;
+    private final FcmTokenService fcmTokenService;
     private final FirebaseMessaging firebaseMessaging;
     private final Executor fcmTaskExecutor;
 
@@ -65,7 +65,7 @@ public class FcmSendService {
                 log.error("FCM 전송 중 오류 발생: {}", throwable.getMessage(), throwable);
 
                 try {
-                    memberFcmTokenService.deleteToken(token);
+                    fcmTokenService.deleteToken(token);
                 } catch (Exception e) {
                     log.warn("FCM 토큰 삭제 중 오류 발생: {}", e.getMessage(), e);
                 }
@@ -87,7 +87,7 @@ public class FcmSendService {
             public void onSuccess(String messageId) {
                 log.info("FCM 전송 성공: messageId={}", messageId);
 
-                memberFcmTokenService.updateLastUsedAt(token);
+                fcmTokenService.updateLastUsedAt(token);
                 NotificationHistoryPayload notificationHistoryPayload = NotificationHistoryPayload.of(
                         memberId,
                         NOTIFICATION_HISTORY_TYPE,

--- a/src/main/java/com/sparta/couponpop/domain/auth/service/AuthService.java
+++ b/src/main/java/com/sparta/couponpop/domain/auth/service/AuthService.java
@@ -11,9 +11,9 @@ import com.sparta.couponpop.domain.auth.dto.response.LoginResponse;
 import com.sparta.couponpop.domain.auth.dto.response.SignUpResponse;
 import com.sparta.couponpop.domain.auth.event.TokenBlacklistEvent;
 import com.sparta.couponpop.domain.auth.exception.AuthErrorCode;
+import com.sparta.couponpop.domain.fcmtoken.repository.FcmTokenRepository;
 import com.sparta.couponpop.domain.member.entity.Member;
 import com.sparta.couponpop.domain.member.exception.MemberErrorCode;
-import com.sparta.couponpop.domain.member.repository.MemberFcmTokenRepository;
 import com.sparta.couponpop.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,7 +34,7 @@ public class AuthService {
     private final JwtProvider jwtProvider;
 
     private final MemberRepository memberRepository;
-    private final MemberFcmTokenRepository memberFcmTokenRepository;
+    private final FcmTokenRepository fcmTokenRepository;
     private final TokenBlacklistService tokenBlacklistService;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -128,9 +128,9 @@ public class AuthService {
     // FCM 토큰 삭제는 실패하더라도 전체 작업이 롤백되지는 않도록 ifPresent 사용
     private void expireFcmToken(Long memberId, String fcmToken) {
 
-        memberFcmTokenRepository
+        fcmTokenRepository
                 .findByMemberIdAndFcmToken(memberId, fcmToken)
-                .ifPresent(memberFcmTokenRepository::delete);
+                .ifPresent(fcmTokenRepository::delete);
     }
 
     private String extractToken(String authorizationHeader) {

--- a/src/main/java/com/sparta/couponpop/domain/fcmtoken/controller/FcmTokenController.java
+++ b/src/main/java/com/sparta/couponpop/domain/fcmtoken/controller/FcmTokenController.java
@@ -20,8 +20,8 @@ public class FcmTokenController {
 
     private final FcmTokenService fcmTokenService;
 
-    @PostMapping("/members/fcm-token")
-    public ResponseEntity<ApiResponse<Void>> upsertMemberFcmToken(@RequestBody @Valid FcmTokenRequest request, @CurrentMember AuthMember authMember) {
+    @PostMapping("/fcm-token")
+    public ResponseEntity<ApiResponse<Void>> upsertFcmToken(@RequestBody @Valid FcmTokenRequest request, @CurrentMember AuthMember authMember) {
         fcmTokenService.upsertTokenForMember(request, authMember.id());
         return ApiResponse.noContent();
     }

--- a/src/main/java/com/sparta/couponpop/domain/fcmtoken/controller/FcmTokenController.java
+++ b/src/main/java/com/sparta/couponpop/domain/fcmtoken/controller/FcmTokenController.java
@@ -1,10 +1,10 @@
-package com.sparta.couponpop.domain.member.controller;
+package com.sparta.couponpop.domain.fcmtoken.controller;
 
 import com.sparta.couponpop.common.response.ApiResponse;
 import com.sparta.couponpop.common.security.annotation.CurrentMember;
 import com.sparta.couponpop.common.security.dto.AuthMember;
-import com.sparta.couponpop.domain.member.dto.request.MemberFcmTokenRequest;
-import com.sparta.couponpop.domain.member.service.MemberFcmTokenService;
+import com.sparta.couponpop.domain.fcmtoken.dto.request.FcmTokenRequest;
+import com.sparta.couponpop.domain.fcmtoken.service.FcmTokenService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,13 +16,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
-public class MemberFcmTokenController {
+public class FcmTokenController {
 
-    private final MemberFcmTokenService memberFcmTokenService;
+    private final FcmTokenService fcmTokenService;
 
     @PostMapping("/members/fcm-token")
-    public ResponseEntity<ApiResponse<Void>> upsertMemberFcmToken(@RequestBody @Valid MemberFcmTokenRequest request, @CurrentMember AuthMember authMember) {
-        memberFcmTokenService.upsertTokenForMember(request, authMember.id());
+    public ResponseEntity<ApiResponse<Void>> upsertMemberFcmToken(@RequestBody @Valid FcmTokenRequest request, @CurrentMember AuthMember authMember) {
+        fcmTokenService.upsertTokenForMember(request, authMember.id());
         return ApiResponse.noContent();
     }
 

--- a/src/main/java/com/sparta/couponpop/domain/fcmtoken/dto/request/FcmTokenRequest.java
+++ b/src/main/java/com/sparta/couponpop/domain/fcmtoken/dto/request/FcmTokenRequest.java
@@ -1,9 +1,9 @@
-package com.sparta.couponpop.domain.member.dto.request;
+package com.sparta.couponpop.domain.fcmtoken.dto.request;
 
 import lombok.Builder;
 
 @Builder
-public record MemberFcmTokenRequest(
+public record FcmTokenRequest(
         String fcmToken,
         String deviceType,
         String deviceIdentifier

--- a/src/main/java/com/sparta/couponpop/domain/fcmtoken/entity/FcmToken.java
+++ b/src/main/java/com/sparta/couponpop/domain/fcmtoken/entity/FcmToken.java
@@ -1,6 +1,7 @@
-package com.sparta.couponpop.domain.member.entity;
+package com.sparta.couponpop.domain.fcmtoken.entity;
 
 import com.sparta.couponpop.common.entity.BaseEntity;
+import com.sparta.couponpop.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -11,11 +12,11 @@ import org.hibernate.annotations.DynamicUpdate;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "member_fcm_tokens")
+@Table(name = "fcm_tokens")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DynamicUpdate
-public class MemberFcmToken extends BaseEntity {
+public class FcmToken extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -36,12 +37,12 @@ public class MemberFcmToken extends BaseEntity {
     private LocalDateTime lastUsedAt;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private MemberFcmToken(Member member,
-                           String fcmToken,
-                           String deviceType,
-                           String deviceIdentifier,
-                           boolean notificationEnabled,
-                           LocalDateTime lastUsedAt) {
+    private FcmToken(Member member,
+                     String fcmToken,
+                     String deviceType,
+                     String deviceIdentifier,
+                     boolean notificationEnabled,
+                     LocalDateTime lastUsedAt) {
         this.member = member;
         this.fcmToken = fcmToken;
         this.deviceType = deviceType;
@@ -50,13 +51,13 @@ public class MemberFcmToken extends BaseEntity {
         this.lastUsedAt = lastUsedAt;
     }
 
-    public static MemberFcmToken of(Member member,
-                                    String fcmToken,
-                                    String deviceType,
-                                    String deviceIdentifier,
-                                    boolean notificationEnabled,
-                                    LocalDateTime lastUsedAt) {
-        return MemberFcmToken.builder()
+    public static FcmToken of(Member member,
+                              String fcmToken,
+                              String deviceType,
+                              String deviceIdentifier,
+                              boolean notificationEnabled,
+                              LocalDateTime lastUsedAt) {
+        return FcmToken.builder()
                 .member(member)
                 .fcmToken(fcmToken)
                 .deviceType(deviceType)

--- a/src/main/java/com/sparta/couponpop/domain/fcmtoken/exception/FcmTokenErrorCode.java
+++ b/src/main/java/com/sparta/couponpop/domain/fcmtoken/exception/FcmTokenErrorCode.java
@@ -1,0 +1,16 @@
+package com.sparta.couponpop.domain.fcmtoken.exception;
+
+import com.sparta.couponpop.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum FcmTokenErrorCode implements ErrorCode {
+
+    FCM_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "FCM 토큰을 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/sparta/couponpop/domain/fcmtoken/repository/FcmTokenRepository.java
+++ b/src/main/java/com/sparta/couponpop/domain/fcmtoken/repository/FcmTokenRepository.java
@@ -1,7 +1,7 @@
-package com.sparta.couponpop.domain.member.repository;
+package com.sparta.couponpop.domain.fcmtoken.repository;
 
+import com.sparta.couponpop.domain.fcmtoken.entity.FcmToken;
 import com.sparta.couponpop.domain.member.entity.Member;
-import com.sparta.couponpop.domain.member.entity.MemberFcmToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -12,15 +12,15 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-public interface MemberFcmTokenRepository extends JpaRepository<MemberFcmToken, Long> {
+public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
 
-    Optional<MemberFcmToken> findByMemberAndDeviceIdentifier(Member member, String deviceIdentifier);
+    Optional<FcmToken> findByMemberAndDeviceIdentifier(Member member, String deviceIdentifier);
 
-    Optional<MemberFcmToken> findByFcmToken(String fcmToken);
+    Optional<FcmToken> findByFcmToken(String fcmToken);
 
-    List<MemberFcmToken> findByMemberAndNotificationEnabledIsTrue(Member member);
+    List<FcmToken> findByMemberAndNotificationEnabledIsTrue(Member member);
 
-    Optional<MemberFcmToken> findByMemberIdAndFcmToken(Long memberId, String fcmToken);
+    Optional<FcmToken> findByMemberIdAndFcmToken(Long memberId, String fcmToken);
 
     /**
      * 다중 FCM 토큰의 lastUsedAt 일괄 업데이트
@@ -31,7 +31,7 @@ public interface MemberFcmTokenRepository extends JpaRepository<MemberFcmToken, 
      */
     @Modifying(clearAutomatically = true)
     @Query("""
-                UPDATE MemberFcmToken t
+                UPDATE FcmToken t
                 SET t.lastUsedAt = :now
                 WHERE t.fcmToken IN :fcmTokens
             """)
@@ -46,7 +46,7 @@ public interface MemberFcmTokenRepository extends JpaRepository<MemberFcmToken, 
      */
     @Modifying(clearAutomatically = true)
     @Query("""
-                DELETE FROM MemberFcmToken t
+                DELETE FROM FcmToken t
                 WHERE t.fcmToken IN :fcmTokens
             """)
     int deleteByFcmTokenIn(@Param("fcmTokens") Set<String> fcmTokens);

--- a/src/main/java/com/sparta/couponpop/domain/fcmtoken/service/FcmTokenService.java
+++ b/src/main/java/com/sparta/couponpop/domain/fcmtoken/service/FcmTokenService.java
@@ -1,11 +1,11 @@
-package com.sparta.couponpop.domain.member.service;
+package com.sparta.couponpop.domain.fcmtoken.service;
 
 import com.sparta.couponpop.common.exception.GlobalException;
-import com.sparta.couponpop.domain.member.dto.request.MemberFcmTokenRequest;
+import com.sparta.couponpop.domain.fcmtoken.dto.request.FcmTokenRequest;
+import com.sparta.couponpop.domain.fcmtoken.entity.FcmToken;
+import com.sparta.couponpop.domain.fcmtoken.repository.FcmTokenRepository;
 import com.sparta.couponpop.domain.member.entity.Member;
-import com.sparta.couponpop.domain.member.entity.MemberFcmToken;
 import com.sparta.couponpop.domain.member.exception.MemberErrorCode;
-import com.sparta.couponpop.domain.member.repository.MemberFcmTokenRepository;
 import com.sparta.couponpop.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,20 +19,20 @@ import java.util.Set;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class MemberFcmTokenService {
+public class FcmTokenService {
 
-    private final MemberFcmTokenRepository memberFcmTokenRepository;
+    private final FcmTokenRepository fcmTokenRepository;
     private final MemberRepository memberRepository;
 
     @Transactional
-    public void upsertTokenForMember(MemberFcmTokenRequest request, Long memberId) {
+    public void upsertTokenForMember(FcmTokenRequest request, Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new GlobalException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         final LocalDateTime now = LocalDateTime.now();
 
         // 중복 토큰 조회
-        Optional<MemberFcmToken> duplicatedToken = memberFcmTokenRepository.findByFcmToken(request.fcmToken());
+        Optional<FcmToken> duplicatedToken = fcmTokenRepository.findByFcmToken(request.fcmToken());
         // 중복 토큰이 있다면 memberId, deviceIdentifier 갱신 후 return
         if (duplicatedToken.isPresent()) {
             duplicatedToken.get().updateMemberAndDeviceIdentifier(
@@ -48,7 +48,7 @@ public class MemberFcmTokenService {
         }
 
         // 중복 토큰이 없다면 기존 토큰 조회 후 UPSERT
-        memberFcmTokenRepository.findByMemberAndDeviceIdentifier(member, request.deviceIdentifier())
+        fcmTokenRepository.findByMemberAndDeviceIdentifier(member, request.deviceIdentifier())
                 .ifPresentOrElse(
                         activeToken -> {
                             activeToken.updateFcmToken(request.fcmToken(), now);
@@ -56,8 +56,8 @@ public class MemberFcmTokenService {
                                     member.getId(), request.deviceIdentifier(), request.fcmToken());
                         },
                         () -> {
-                            memberFcmTokenRepository.save(
-                                    MemberFcmToken.of(
+                            fcmTokenRepository.save(
+                                    FcmToken.of(
                                             member,
                                             request.fcmToken(),
                                             request.deviceType(),
@@ -75,7 +75,7 @@ public class MemberFcmTokenService {
     // 단일 토큰 최근 사용 날짜(lastUsedAt) UPDATE
     @Transactional
     public void updateLastUsedAt(String fcmToken) {
-        MemberFcmToken memberFcmToken = memberFcmTokenRepository.findByFcmToken(fcmToken)
+        FcmToken memberFcmToken = fcmTokenRepository.findByFcmToken(fcmToken)
                 .orElseThrow(() -> new GlobalException(MemberErrorCode.MEMBER_FCM_TOKEN_NOT_FOUND));
 
         memberFcmToken.updateLastUsedAt(LocalDateTime.now());
@@ -84,10 +84,10 @@ public class MemberFcmTokenService {
     // 단일 토큰 삭제
     @Transactional
     public void deleteToken(String fcmToken) {
-        MemberFcmToken memberFcmToken = memberFcmTokenRepository.findByFcmToken(fcmToken)
+        FcmToken memberFcmToken = fcmTokenRepository.findByFcmToken(fcmToken)
                 .orElseThrow(() -> new GlobalException(MemberErrorCode.MEMBER_FCM_TOKEN_NOT_FOUND));
 
-        memberFcmTokenRepository.delete(memberFcmToken);
+        fcmTokenRepository.delete(memberFcmToken);
     }
 
     /**
@@ -111,7 +111,7 @@ public class MemberFcmTokenService {
             return;
         }
 
-        int updatedCount = memberFcmTokenRepository.updateLastUsedAtByFcmTokenIn(fcmTokens, now);
+        int updatedCount = fcmTokenRepository.updateLastUsedAtByFcmTokenIn(fcmTokens, now);
         log.info("FCM 성공 토큰 {}개 최근 사용 날짜 업데이트 완료", updatedCount);
     }
 
@@ -120,7 +120,7 @@ public class MemberFcmTokenService {
             return;
         }
 
-        int deletedCount = memberFcmTokenRepository.deleteByFcmTokenIn(fcmTokens);
+        int deletedCount = fcmTokenRepository.deleteByFcmTokenIn(fcmTokens);
         log.info("FCM 실패 토큰 {}개 삭제 완료", deletedCount);
     }
 }

--- a/src/main/java/com/sparta/couponpop/domain/fcmtoken/service/FcmTokenService.java
+++ b/src/main/java/com/sparta/couponpop/domain/fcmtoken/service/FcmTokenService.java
@@ -3,6 +3,7 @@ package com.sparta.couponpop.domain.fcmtoken.service;
 import com.sparta.couponpop.common.exception.GlobalException;
 import com.sparta.couponpop.domain.fcmtoken.dto.request.FcmTokenRequest;
 import com.sparta.couponpop.domain.fcmtoken.entity.FcmToken;
+import com.sparta.couponpop.domain.fcmtoken.exception.FcmTokenErrorCode;
 import com.sparta.couponpop.domain.fcmtoken.repository.FcmTokenRepository;
 import com.sparta.couponpop.domain.member.entity.Member;
 import com.sparta.couponpop.domain.member.exception.MemberErrorCode;
@@ -76,7 +77,7 @@ public class FcmTokenService {
     @Transactional
     public void updateLastUsedAt(String fcmToken) {
         FcmToken fcmtoken = fcmTokenRepository.findByFcmToken(fcmToken)
-                .orElseThrow(() -> new GlobalException(MemberErrorCode.MEMBER_FCM_TOKEN_NOT_FOUND));
+                .orElseThrow(() -> new GlobalException(FcmTokenErrorCode.FCM_TOKEN_NOT_FOUND));
 
         fcmtoken.updateLastUsedAt(LocalDateTime.now());
     }
@@ -85,7 +86,7 @@ public class FcmTokenService {
     @Transactional
     public void deleteToken(String token) {
         FcmToken fcmToken = fcmTokenRepository.findByFcmToken(token)
-                .orElseThrow(() -> new GlobalException(MemberErrorCode.MEMBER_FCM_TOKEN_NOT_FOUND));
+                .orElseThrow(() -> new GlobalException(FcmTokenErrorCode.FCM_TOKEN_NOT_FOUND));
 
         fcmTokenRepository.delete(fcmToken);
     }

--- a/src/main/java/com/sparta/couponpop/domain/fcmtoken/service/FcmTokenService.java
+++ b/src/main/java/com/sparta/couponpop/domain/fcmtoken/service/FcmTokenService.java
@@ -75,19 +75,19 @@ public class FcmTokenService {
     // 단일 토큰 최근 사용 날짜(lastUsedAt) UPDATE
     @Transactional
     public void updateLastUsedAt(String fcmToken) {
-        FcmToken memberFcmToken = fcmTokenRepository.findByFcmToken(fcmToken)
+        FcmToken fcmtoken = fcmTokenRepository.findByFcmToken(fcmToken)
                 .orElseThrow(() -> new GlobalException(MemberErrorCode.MEMBER_FCM_TOKEN_NOT_FOUND));
 
-        memberFcmToken.updateLastUsedAt(LocalDateTime.now());
+        fcmtoken.updateLastUsedAt(LocalDateTime.now());
     }
 
     // 단일 토큰 삭제
     @Transactional
-    public void deleteToken(String fcmToken) {
-        FcmToken memberFcmToken = fcmTokenRepository.findByFcmToken(fcmToken)
+    public void deleteToken(String token) {
+        FcmToken fcmToken = fcmTokenRepository.findByFcmToken(token)
                 .orElseThrow(() -> new GlobalException(MemberErrorCode.MEMBER_FCM_TOKEN_NOT_FOUND));
 
-        fcmTokenRepository.delete(memberFcmToken);
+        fcmTokenRepository.delete(fcmToken);
     }
 
     /**

--- a/src/main/java/com/sparta/couponpop/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/sparta/couponpop/domain/member/exception/MemberErrorCode.java
@@ -11,7 +11,6 @@ public enum MemberErrorCode implements ErrorCode {
 
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
     EMAIL_DUPLICATED(HttpStatus.BAD_REQUEST, "이미 사용중인 이메일입니다."),
-    MEMBER_FCM_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "회원 FCM 토큰을 찾을 수 없습니다."),
     PASSWORD_INPUT_INCOMPLETE(HttpStatus.BAD_REQUEST, "비밀번호 변경은 비밀번호, 비밀번호 확인 모두 입력해야 합니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/sparta/couponpop/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/sparta/couponpop/domain/notification/service/NotificationService.java
@@ -2,10 +2,10 @@ package com.sparta.couponpop.domain.notification.service;
 
 import com.sparta.couponpop.common.exception.GlobalException;
 import com.sparta.couponpop.common.fcm.service.FcmSendService;
+import com.sparta.couponpop.domain.fcmtoken.entity.FcmToken;
+import com.sparta.couponpop.domain.fcmtoken.repository.FcmTokenRepository;
 import com.sparta.couponpop.domain.member.entity.Member;
-import com.sparta.couponpop.domain.member.entity.MemberFcmToken;
 import com.sparta.couponpop.domain.member.exception.MemberErrorCode;
-import com.sparta.couponpop.domain.member.repository.MemberFcmTokenRepository;
 import com.sparta.couponpop.domain.member.repository.MemberRepository;
 import com.sparta.couponpop.domain.notification.constants.NotificationTemplates;
 import com.sparta.couponpop.domain.notification.dto.payload.CouponIssuedNotificationPayload;
@@ -25,7 +25,7 @@ import java.util.List;
 public class NotificationService {
 
     private final MemberRepository memberRepository;
-    private final MemberFcmTokenRepository memberFcmTokenRepository;
+    private final FcmTokenRepository fcmTokenRepository;
     private final FcmSendService fcmSendService;
 
     /**
@@ -77,7 +77,7 @@ public class NotificationService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new GlobalException(MemberErrorCode.MEMBER_NOT_FOUND));
 
-        List<MemberFcmToken> enabledTokens = memberFcmTokenRepository.findByMemberAndNotificationEnabledIsTrue(member);
+        List<FcmToken> enabledTokens = fcmTokenRepository.findByMemberAndNotificationEnabledIsTrue(member);
         if (enabledTokens.isEmpty()) {
             log.info("푸시 알림이 활성화된 FCM 토큰이 없어 알림을 건너뜁니다. memberId={}", member.getId());
             return List.of();
@@ -85,7 +85,7 @@ public class NotificationService {
 
         // 토큰 중복 제거
         return enabledTokens.stream()
-                .map(MemberFcmToken::getFcmToken)
+                .map(FcmToken::getFcmToken)
                 .distinct()
                 .toList();
     }

--- a/src/main/resources/db/migration/V23__rename_member_fcm_tokens_table.sql
+++ b/src/main/resources/db/migration/V23__rename_member_fcm_tokens_table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE member_fcm_tokens RENAME TO fcm_tokens;

--- a/src/test/java/com/sparta/couponpop/common/fcm/service/FcmSendServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/common/fcm/service/FcmSendServiceTest.java
@@ -5,7 +5,7 @@ import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.sparta.couponpop.common.fcm.factory.FcmMessageFactory;
-import com.sparta.couponpop.domain.member.service.MemberFcmTokenService;
+import com.sparta.couponpop.domain.fcmtoken.service.FcmTokenService;
 import com.sparta.couponpop.domain.notificationhistory.dto.payload.NotificationHistoryPayload;
 import com.sparta.couponpop.domain.notificationhistory.enums.NotificationHistoryStatus;
 import com.sparta.couponpop.domain.notificationhistory.enums.NotificationHistoryType;
@@ -35,7 +35,7 @@ class FcmSendServiceTest {
     private NotificationHistoryService notificationHistoryService;
 
     @Mock
-    private MemberFcmTokenService memberFcmTokenService;
+    private FcmTokenService fcmTokenService;
 
     @Mock
     private FirebaseMessaging firebaseMessaging;
@@ -85,7 +85,7 @@ class FcmSendServiceTest {
 
             // then
             verify(firebaseMessaging).sendAsync(message);
-            verify(memberFcmTokenService).updateLastUsedAt(token);
+            verify(fcmTokenService).updateLastUsedAt(token);
             verify(notificationHistoryService).createNotificationHistory(payload);
             assertThat(result.isDone()).isTrue();
             assertThat(result.join()).isNull();
@@ -120,7 +120,7 @@ class FcmSendServiceTest {
             // then
             assertThat(result.isCompletedExceptionally()).isTrue();
             verify(firebaseMessaging).sendAsync(message);
-            verify(memberFcmTokenService).deleteToken(token);
+            verify(fcmTokenService).deleteToken(token);
             verify(notificationHistoryService).createNotificationHistory(payload);
         }
 
@@ -137,7 +137,7 @@ class FcmSendServiceTest {
             // then
             assertThat(result.isDone()).isTrue();
             assertThat(result.join()).isNull();
-            verifyNoInteractions(fcmMessageFactory, memberFcmTokenService, notificationHistoryService);
+            verifyNoInteractions(fcmMessageFactory, fcmTokenService, notificationHistoryService);
         }
     }
 }

--- a/src/test/java/com/sparta/couponpop/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/auth/service/AuthServiceTest.java
@@ -11,11 +11,11 @@ import com.sparta.couponpop.domain.auth.dto.response.LoginResponse;
 import com.sparta.couponpop.domain.auth.dto.response.SignUpResponse;
 import com.sparta.couponpop.domain.auth.event.TokenBlacklistEvent;
 import com.sparta.couponpop.domain.auth.exception.AuthErrorCode;
+import com.sparta.couponpop.domain.fcmtoken.entity.FcmToken;
+import com.sparta.couponpop.domain.fcmtoken.repository.FcmTokenRepository;
 import com.sparta.couponpop.domain.member.entity.Member;
-import com.sparta.couponpop.domain.member.entity.MemberFcmToken;
 import com.sparta.couponpop.domain.member.enums.MemberType;
 import com.sparta.couponpop.domain.member.exception.MemberErrorCode;
-import com.sparta.couponpop.domain.member.repository.MemberFcmTokenRepository;
 import com.sparta.couponpop.domain.member.repository.MemberRepository;
 import com.sparta.couponpop.domain.member.service.MemberService;
 import com.sparta.couponpop.utils.TestUtils;
@@ -51,7 +51,7 @@ class AuthServiceTest {
     private MemberRepository memberRepository;
 
     @Mock
-    private MemberFcmTokenRepository memberFcmTokenRepository;
+    private FcmTokenRepository fcmTokenRepository;
 
     @Mock
     private JwtProvider jwtProvider;
@@ -232,12 +232,12 @@ class AuthServiceTest {
         void logoutSuccess() {
 
             // given
-            MemberFcmToken mockFcmToken = TestUtils.createEntity(MemberFcmToken.class, Map.of("fcmToken", "testFcmToken"));
+            FcmToken mockFcmToken = TestUtils.createEntity(FcmToken.class, Map.of("fcmToken", "testFcmToken"));
 
             given(jwtProvider.resolveToken(testAuthorizationHeader)).willReturn(testToken);
             given(jwtProvider.getExpirationMillis(testToken)).willReturn(testExpirationMillis);
 
-            given(memberFcmTokenRepository.findByMemberIdAndFcmToken(testAuthMember.id(), testLogoutRequest.fcmToken()))
+            given(fcmTokenRepository.findByMemberIdAndFcmToken(testAuthMember.id(), testLogoutRequest.fcmToken()))
                     .willReturn(Optional.of(mockFcmToken));
 
             // when
@@ -250,8 +250,8 @@ class AuthServiceTest {
             verify(tokenBlacklistService).blacklistToken(testToken, testExpirationMillis);
 
             // 2. FCM Token 검증
-            verify(memberFcmTokenRepository).findByMemberIdAndFcmToken(testAuthMember.id(), testLogoutRequest.fcmToken());
-            verify(memberFcmTokenRepository).delete(mockFcmToken);
+            verify(fcmTokenRepository).findByMemberIdAndFcmToken(testAuthMember.id(), testLogoutRequest.fcmToken());
+            verify(fcmTokenRepository).delete(mockFcmToken);
         }
 
         @Test
@@ -269,7 +269,7 @@ class AuthServiceTest {
             });
 
             assertThat(exception.getErrorCode()).isEqualTo(AuthErrorCode.INVALID_TOKEN);
-            verify(memberFcmTokenRepository, never()).findByMemberIdAndFcmToken(anyLong(), anyString());
+            verify(fcmTokenRepository, never()).findByMemberIdAndFcmToken(anyLong(), anyString());
         }
 
         @Test
@@ -278,12 +278,12 @@ class AuthServiceTest {
 
             // given
             testLogoutRequest = new LogoutRequest("testFcmToken");
-            MemberFcmToken mockFcmToken = TestUtils.createEntity(MemberFcmToken.class, Map.of("fcmToken", "testFcmToken"));
+            FcmToken mockFcmToken = TestUtils.createEntity(FcmToken.class, Map.of("fcmToken", "testFcmToken"));
 
             given(jwtProvider.resolveToken(testAuthorizationHeader)).willReturn(testToken);
             given(jwtProvider.getExpirationMillis(testToken)).willReturn(testExpirationMillis);
 
-            given(memberFcmTokenRepository.findByMemberIdAndFcmToken(testAuthMember.id(), testLogoutRequest.fcmToken()))
+            given(fcmTokenRepository.findByMemberIdAndFcmToken(testAuthMember.id(), testLogoutRequest.fcmToken()))
                     .willReturn(Optional.empty());
 
             // when
@@ -296,7 +296,7 @@ class AuthServiceTest {
             verify(tokenBlacklistService).blacklistToken(testToken, testExpirationMillis);
 
             // 2. FCM Token 검증
-            verify(memberFcmTokenRepository).findByMemberIdAndFcmToken(testAuthMember.id(), testLogoutRequest.fcmToken());
+            verify(fcmTokenRepository).findByMemberIdAndFcmToken(testAuthMember.id(), testLogoutRequest.fcmToken());
         }
     }
 
@@ -319,7 +319,7 @@ class AuthServiceTest {
             ));
 
             WithdrawRequest testWithdrawRequest = new WithdrawRequest("testFcmToken");
-            MemberFcmToken mockFcmToken = TestUtils.createEntity(MemberFcmToken.class, Map.of("fcmToken", "testFcmToken"));
+            FcmToken mockFcmToken = TestUtils.createEntity(FcmToken.class, Map.of("fcmToken", "testFcmToken"));
 
             // member 조회
             given(memberRepository.findById(testAuthMember.id())).willReturn(Optional.of(mockMember));
@@ -329,7 +329,7 @@ class AuthServiceTest {
             given(jwtProvider.getExpirationMillis(testToken)).willReturn(testExpirationMillis);
 
             // FCM 토큰
-            given(memberFcmTokenRepository.findByMemberIdAndFcmToken(testAuthMember.id(), testWithdrawRequest.fcmToken()))
+            given(fcmTokenRepository.findByMemberIdAndFcmToken(testAuthMember.id(), testWithdrawRequest.fcmToken()))
                     .willReturn(Optional.of(mockFcmToken));
 
             // when
@@ -341,8 +341,8 @@ class AuthServiceTest {
                     .isBeforeOrEqualTo(LocalDateTime.now());
 
             // FCM 토큰
-            verify(memberFcmTokenRepository).findByMemberIdAndFcmToken(testAuthMember.id(), testWithdrawRequest.fcmToken());
-            verify(memberFcmTokenRepository).delete(mockFcmToken);
+            verify(fcmTokenRepository).findByMemberIdAndFcmToken(testAuthMember.id(), testWithdrawRequest.fcmToken());
+            verify(fcmTokenRepository).delete(mockFcmToken);
 
             // JWT
             verify(eventPublisher).publishEvent(any(TokenBlacklistEvent.class));
@@ -367,7 +367,7 @@ class AuthServiceTest {
 
             assertThat(exception.getErrorCode()).isEqualTo(MemberErrorCode.MEMBER_NOT_FOUND);
 
-            verify(memberFcmTokenRepository, never()).delete(any());
+            verify(fcmTokenRepository, never()).delete(any());
             verify(eventPublisher, never()).publishEvent(any());
         }
     }

--- a/src/test/java/com/sparta/couponpop/domain/fcmtoken/controller/FcmTokenControllerTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/fcmtoken/controller/FcmTokenControllerTest.java
@@ -1,4 +1,4 @@
-package com.sparta.couponpop.domain.member.controller;
+package com.sparta.couponpop.domain.fcmtoken.controller;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
@@ -7,7 +7,6 @@ import com.sparta.couponpop.common.security.JwtAuthFilter;
 import com.sparta.couponpop.common.security.JwtAuthenticationToken;
 import com.sparta.couponpop.common.security.JwtProvider;
 import com.sparta.couponpop.common.security.dto.AuthMember;
-import com.sparta.couponpop.domain.fcmtoken.controller.FcmTokenController;
 import com.sparta.couponpop.domain.fcmtoken.dto.request.FcmTokenRequest;
 import com.sparta.couponpop.domain.fcmtoken.service.FcmTokenService;
 import com.sparta.couponpop.domain.member.enums.MemberType;
@@ -74,14 +73,14 @@ class FcmTokenControllerTest {
     }
 
     @Nested
-    @DisplayName("POST /api/v1/members/fcm-token")
+    @DisplayName("POST /api/v1/fcm-tokens")
     class UpsertFcmToken {
 
-        private static final String URL = "/api/v1/members/fcm-token";
+        private static final String URL = "/api/v1/fcm-token";
 
         @Test
-        @DisplayName("회원 FCM 토큰 생성 및 갱신 - 성공")
-        void upsertMemberFcmToken_success() throws Exception {
+        @DisplayName("FCM 토큰 생성 및 갱신 - 성공")
+        void upsertFcmToken_success() throws Exception {
             // given
             FcmTokenRequest request = FcmTokenRequest.builder()
                     .fcmToken("sample_fcm_token")
@@ -104,15 +103,15 @@ class FcmTokenControllerTest {
                     .andExpect(status().isNoContent());
 
             // docs
-            resultActions.andDo(document("member-fcmTokenUpsert",
+            resultActions.andDo(document("fcmtoken-fcmTokenUpsert",
                     preprocessRequest(prettyPrint()),
                     preprocessResponse(prettyPrint()),
                     resource(
                             ResourceSnippetParameters.builder()
-                                    .summary("회원 FCM 토큰 생성 및 갱신")
+                                    .summary("FCM 토큰 생성 및 갱신")
                                     .description("회원의 FCM 토큰을 생성하거나 갱신합니다.")
-                                    .tag("Member FCM Token")
-                                    .requestSchema(Schema.schema("Member.MemberFcmTokenRequest"))
+                                    .tag("FCM Token")
+                                    .requestSchema(Schema.schema("FcmToken.fcmTokenRequest"))
                                     .requestFields(
                                             fieldWithPath("fcmToken").description("FCM 토큰"),
                                             fieldWithPath("deviceType").description("디바이스 타입 (예: ANDROID, IOS)"),

--- a/src/test/java/com/sparta/couponpop/domain/fcmtoken/service/FcmTokenServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/fcmtoken/service/FcmTokenServiceTest.java
@@ -3,6 +3,7 @@ package com.sparta.couponpop.domain.fcmtoken.service;
 import com.sparta.couponpop.common.exception.GlobalException;
 import com.sparta.couponpop.domain.fcmtoken.dto.request.FcmTokenRequest;
 import com.sparta.couponpop.domain.fcmtoken.entity.FcmToken;
+import com.sparta.couponpop.domain.fcmtoken.exception.FcmTokenErrorCode;
 import com.sparta.couponpop.domain.fcmtoken.repository.FcmTokenRepository;
 import com.sparta.couponpop.domain.member.entity.Member;
 import com.sparta.couponpop.domain.member.exception.MemberErrorCode;
@@ -187,7 +188,7 @@ class FcmTokenServiceTest {
             // when & then
             assertThatThrownBy(() -> fcmTokenService.updateLastUsedAt(token))
                     .isInstanceOf(GlobalException.class)
-                    .hasMessage(MemberErrorCode.MEMBER_FCM_TOKEN_NOT_FOUND.getMessage());
+                    .hasMessage(FcmTokenErrorCode.FCM_TOKEN_NOT_FOUND.getMessage());
 
             then(fcmTokenRepository).should(times(1)).findByFcmToken(token);
         }
@@ -223,7 +224,7 @@ class FcmTokenServiceTest {
             // when & then
             assertThatThrownBy(() -> fcmTokenService.deleteToken(token))
                     .isInstanceOf(GlobalException.class)
-                    .hasMessage(MemberErrorCode.MEMBER_FCM_TOKEN_NOT_FOUND.getMessage());
+                    .hasMessage(FcmTokenErrorCode.FCM_TOKEN_NOT_FOUND.getMessage());
 
             then(fcmTokenRepository).should(times(1)).findByFcmToken(token);
             then(fcmTokenRepository).should(never()).delete(any(FcmToken.class));

--- a/src/test/java/com/sparta/couponpop/domain/fcmtoken/service/FcmTokenServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/fcmtoken/service/FcmTokenServiceTest.java
@@ -1,10 +1,9 @@
-package com.sparta.couponpop.domain.member.service;
+package com.sparta.couponpop.domain.fcmtoken.service;
 
 import com.sparta.couponpop.common.exception.GlobalException;
 import com.sparta.couponpop.domain.fcmtoken.dto.request.FcmTokenRequest;
 import com.sparta.couponpop.domain.fcmtoken.entity.FcmToken;
 import com.sparta.couponpop.domain.fcmtoken.repository.FcmTokenRepository;
-import com.sparta.couponpop.domain.fcmtoken.service.FcmTokenService;
 import com.sparta.couponpop.domain.member.entity.Member;
 import com.sparta.couponpop.domain.member.exception.MemberErrorCode;
 import com.sparta.couponpop.domain.member.repository.MemberRepository;
@@ -58,16 +57,16 @@ class FcmTokenServiceTest {
                     .deviceType("ANDROID")
                     .deviceIdentifier("device-123")
                     .build();
-            FcmToken duplicatedToken = mock(FcmToken.class);
+            FcmToken duplicatedFcmToken = mock(FcmToken.class);
 
             given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-            given(fcmTokenRepository.findByFcmToken(request.fcmToken())).willReturn(Optional.of(duplicatedToken));
+            given(fcmTokenRepository.findByFcmToken(request.fcmToken())).willReturn(Optional.of(duplicatedFcmToken));
 
             // when
             fcmTokenService.upsertTokenForMember(request, memberId);
 
             // then
-            then(duplicatedToken).should(times(1)).updateMemberAndDeviceIdentifier(eq(member), eq(request.deviceIdentifier()), any(LocalDateTime.class));
+            then(duplicatedFcmToken).should(times(1)).updateMemberAndDeviceIdentifier(eq(member), eq(request.deviceIdentifier()), any(LocalDateTime.class));
 
             then(fcmTokenRepository).should(times(1)).findByFcmToken(request.fcmToken());
             then(fcmTokenRepository).should(never()).findByMemberAndDeviceIdentifier(any(Member.class), anyString());
@@ -85,17 +84,17 @@ class FcmTokenServiceTest {
                     .deviceType("IOS")
                     .deviceIdentifier("device-123")
                     .build();
-            FcmToken activeToken = mock(FcmToken.class);
+            FcmToken activeFcmToken = mock(FcmToken.class);
 
             given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
             given(fcmTokenRepository.findByFcmToken(request.fcmToken())).willReturn(Optional.empty());
-            given(fcmTokenRepository.findByMemberAndDeviceIdentifier(member, request.deviceIdentifier())).willReturn(Optional.of(activeToken));
+            given(fcmTokenRepository.findByMemberAndDeviceIdentifier(member, request.deviceIdentifier())).willReturn(Optional.of(activeFcmToken));
 
             // when
             fcmTokenService.upsertTokenForMember(request, memberId);
 
             // then
-            then(activeToken).should(times(1)).updateFcmToken(eq(request.fcmToken()), any(LocalDateTime.class));
+            then(activeFcmToken).should(times(1)).updateFcmToken(eq(request.fcmToken()), any(LocalDateTime.class));
 
             then(fcmTokenRepository).should(times(1)).findByFcmToken(request.fcmToken());
             then(fcmTokenRepository).should(times(1)).findByMemberAndDeviceIdentifier(member, request.deviceIdentifier());
@@ -126,12 +125,12 @@ class FcmTokenServiceTest {
             ArgumentCaptor<FcmToken> tokenCaptor = ArgumentCaptor.forClass(FcmToken.class);
             then(fcmTokenRepository).should(times(1)).save(tokenCaptor.capture());
 
-            FcmToken savedToken = tokenCaptor.getValue();
-            assertThat(savedToken.getMember()).isEqualTo(member);
-            assertThat(savedToken.getFcmToken()).isEqualTo(request.fcmToken());
-            assertThat(savedToken.getDeviceType()).isEqualTo(request.deviceType());
-            assertThat(savedToken.getDeviceIdentifier()).isEqualTo(request.deviceIdentifier());
-            assertThat(savedToken.getLastUsedAt()).isNotNull();
+            FcmToken savedFcmToken = tokenCaptor.getValue();
+            assertThat(savedFcmToken.getMember()).isEqualTo(member);
+            assertThat(savedFcmToken.getFcmToken()).isEqualTo(request.fcmToken());
+            assertThat(savedFcmToken.getDeviceType()).isEqualTo(request.deviceType());
+            assertThat(savedFcmToken.getDeviceIdentifier()).isEqualTo(request.deviceIdentifier());
+            assertThat(savedFcmToken.getLastUsedAt()).isNotNull();
         }
 
         @Test
@@ -166,31 +165,31 @@ class FcmTokenServiceTest {
         @DisplayName("토큰이 존재하면 최근 사용 시간을 갱신한다")
         void updateLastUsedAt_success_tokenExists() {
             // given
-            String fcmToken = "existing-token";
-            FcmToken memberFcmToken = mock(FcmToken.class);
-            given(fcmTokenRepository.findByFcmToken(fcmToken)).willReturn(Optional.of(memberFcmToken));
+            String token = "existing-token";
+            FcmToken fcmToken = mock(FcmToken.class);
+            given(fcmTokenRepository.findByFcmToken(token)).willReturn(Optional.of(fcmToken));
 
             // when
-            fcmTokenService.updateLastUsedAt(fcmToken);
+            fcmTokenService.updateLastUsedAt(token);
 
             // then
-            then(fcmTokenRepository).should(times(1)).findByFcmToken(fcmToken);
-            then(memberFcmToken).should(times(1)).updateLastUsedAt(any(LocalDateTime.class));
+            then(fcmTokenRepository).should(times(1)).findByFcmToken(token);
+            then(fcmToken).should(times(1)).updateLastUsedAt(any(LocalDateTime.class));
         }
 
         @Test
         @DisplayName("토큰이 없으면 예외를 던진다")
         void updateLastUsedAt_fail_tokenNotFound() {
             // given
-            String fcmToken = "missing-token";
-            given(fcmTokenRepository.findByFcmToken(fcmToken)).willReturn(Optional.empty());
+            String token = "missing-token";
+            given(fcmTokenRepository.findByFcmToken(token)).willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> fcmTokenService.updateLastUsedAt(fcmToken))
+            assertThatThrownBy(() -> fcmTokenService.updateLastUsedAt(token))
                     .isInstanceOf(GlobalException.class)
                     .hasMessage(MemberErrorCode.MEMBER_FCM_TOKEN_NOT_FOUND.getMessage());
 
-            then(fcmTokenRepository).should(times(1)).findByFcmToken(fcmToken);
+            then(fcmTokenRepository).should(times(1)).findByFcmToken(token);
         }
     }
 
@@ -202,31 +201,31 @@ class FcmTokenServiceTest {
         @DisplayName("토큰이 존재하면 삭제한다")
         void deleteToken_success_tokenExists() {
             // given
-            String fcmToken = "removable-token";
-            FcmToken memberFcmToken = mock(FcmToken.class);
-            given(fcmTokenRepository.findByFcmToken(fcmToken)).willReturn(Optional.of(memberFcmToken));
+            String token = "removable-token";
+            FcmToken fcmToken = mock(FcmToken.class);
+            given(fcmTokenRepository.findByFcmToken(token)).willReturn(Optional.of(fcmToken));
 
             // when
-            fcmTokenService.deleteToken(fcmToken);
+            fcmTokenService.deleteToken(token);
 
             // then
-            then(fcmTokenRepository).should(times(1)).findByFcmToken(fcmToken);
-            then(fcmTokenRepository).should(times(1)).delete(memberFcmToken);
+            then(fcmTokenRepository).should(times(1)).findByFcmToken(token);
+            then(fcmTokenRepository).should(times(1)).delete(fcmToken);
         }
 
         @Test
         @DisplayName("토큰이 없으면 예외를 던진다")
         void deleteToken_fail_tokenNotFound() {
             // given
-            String fcmToken = "invalid-token";
-            given(fcmTokenRepository.findByFcmToken(fcmToken)).willReturn(Optional.empty());
+            String token = "invalid-token";
+            given(fcmTokenRepository.findByFcmToken(token)).willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> fcmTokenService.deleteToken(fcmToken))
+            assertThatThrownBy(() -> fcmTokenService.deleteToken(token))
                     .isInstanceOf(GlobalException.class)
                     .hasMessage(MemberErrorCode.MEMBER_FCM_TOKEN_NOT_FOUND.getMessage());
 
-            then(fcmTokenRepository).should(times(1)).findByFcmToken(fcmToken);
+            then(fcmTokenRepository).should(times(1)).findByFcmToken(token);
             then(fcmTokenRepository).should(never()).delete(any(FcmToken.class));
         }
     }

--- a/src/test/java/com/sparta/couponpop/domain/member/controller/FcmTokenControllerTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/member/controller/FcmTokenControllerTest.java
@@ -7,9 +7,10 @@ import com.sparta.couponpop.common.security.JwtAuthFilter;
 import com.sparta.couponpop.common.security.JwtAuthenticationToken;
 import com.sparta.couponpop.common.security.JwtProvider;
 import com.sparta.couponpop.common.security.dto.AuthMember;
-import com.sparta.couponpop.domain.member.dto.request.MemberFcmTokenRequest;
+import com.sparta.couponpop.domain.fcmtoken.controller.FcmTokenController;
+import com.sparta.couponpop.domain.fcmtoken.dto.request.FcmTokenRequest;
+import com.sparta.couponpop.domain.fcmtoken.service.FcmTokenService;
 import com.sparta.couponpop.domain.member.enums.MemberType;
-import com.sparta.couponpop.domain.member.service.MemberFcmTokenService;
 import com.sparta.couponpop.domain.store.repository.StoreSearchRepository;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,9 +37,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @AutoConfigureRestDocs
-@WebMvcTest(MemberFcmTokenController.class)
+@WebMvcTest(FcmTokenController.class)
 @AutoConfigureMockMvc(addFilters = false)
-class MemberFcmTokenControllerTest {
+class FcmTokenControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -53,7 +54,7 @@ class MemberFcmTokenControllerTest {
     private JwtAuthFilter jwtAuthFilter;
 
     @MockitoBean
-    private MemberFcmTokenService memberFcmTokenService;
+    private FcmTokenService fcmTokenService;
 
     @MockitoBean
     private StoreSearchRepository storeSearchRepository;
@@ -74,7 +75,7 @@ class MemberFcmTokenControllerTest {
 
     @Nested
     @DisplayName("POST /api/v1/members/fcm-token")
-    class UpsertMemberFcmToken {
+    class UpsertFcmToken {
 
         private static final String URL = "/api/v1/members/fcm-token";
 
@@ -82,13 +83,13 @@ class MemberFcmTokenControllerTest {
         @DisplayName("회원 FCM 토큰 생성 및 갱신 - 성공")
         void upsertMemberFcmToken_success() throws Exception {
             // given
-            MemberFcmTokenRequest request = MemberFcmTokenRequest.builder()
+            FcmTokenRequest request = FcmTokenRequest.builder()
                     .fcmToken("sample_fcm_token")
                     .deviceType("ANDROID")
                     .deviceIdentifier("device-123")
                     .build();
 
-            willDoNothing().given(memberFcmTokenService).upsertTokenForMember(any(MemberFcmTokenRequest.class), anyLong());
+            willDoNothing().given(fcmTokenService).upsertTokenForMember(any(FcmTokenRequest.class), anyLong());
 
             // when
             ResultActions resultActions = mockMvc.perform(

--- a/src/test/java/com/sparta/couponpop/domain/member/service/FcmTokenServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/member/service/FcmTokenServiceTest.java
@@ -1,11 +1,12 @@
 package com.sparta.couponpop.domain.member.service;
 
 import com.sparta.couponpop.common.exception.GlobalException;
-import com.sparta.couponpop.domain.member.dto.request.MemberFcmTokenRequest;
+import com.sparta.couponpop.domain.fcmtoken.dto.request.FcmTokenRequest;
+import com.sparta.couponpop.domain.fcmtoken.entity.FcmToken;
+import com.sparta.couponpop.domain.fcmtoken.repository.FcmTokenRepository;
+import com.sparta.couponpop.domain.fcmtoken.service.FcmTokenService;
 import com.sparta.couponpop.domain.member.entity.Member;
-import com.sparta.couponpop.domain.member.entity.MemberFcmToken;
 import com.sparta.couponpop.domain.member.exception.MemberErrorCode;
-import com.sparta.couponpop.domain.member.repository.MemberFcmTokenRepository;
 import com.sparta.couponpop.domain.member.repository.MemberRepository;
 import com.sparta.couponpop.utils.TestUtils;
 import org.junit.jupiter.api.DisplayName;
@@ -31,16 +32,16 @@ import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.eq;
 
 @ExtendWith(MockitoExtension.class)
-class MemberFcmTokenServiceTest {
+class FcmTokenServiceTest {
 
     @Mock
-    private MemberFcmTokenRepository memberFcmTokenRepository;
+    private FcmTokenRepository fcmTokenRepository;
 
     @Mock
     private MemberRepository memberRepository;
 
     @InjectMocks
-    private MemberFcmTokenService memberFcmTokenService;
+    private FcmTokenService fcmTokenService;
 
     @Nested
     @DisplayName("upsertTokenForMember")
@@ -52,25 +53,25 @@ class MemberFcmTokenServiceTest {
             // given
             Long memberId = 1L;
             Member member = TestUtils.createEntity(Member.class, Map.of("id", memberId));
-            MemberFcmTokenRequest request = MemberFcmTokenRequest.builder()
+            FcmTokenRequest request = FcmTokenRequest.builder()
                     .fcmToken("fcm-token")
                     .deviceType("ANDROID")
                     .deviceIdentifier("device-123")
                     .build();
-            MemberFcmToken duplicatedToken = mock(MemberFcmToken.class);
+            FcmToken duplicatedToken = mock(FcmToken.class);
 
             given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-            given(memberFcmTokenRepository.findByFcmToken(request.fcmToken())).willReturn(Optional.of(duplicatedToken));
+            given(fcmTokenRepository.findByFcmToken(request.fcmToken())).willReturn(Optional.of(duplicatedToken));
 
             // when
-            memberFcmTokenService.upsertTokenForMember(request, memberId);
+            fcmTokenService.upsertTokenForMember(request, memberId);
 
             // then
             then(duplicatedToken).should(times(1)).updateMemberAndDeviceIdentifier(eq(member), eq(request.deviceIdentifier()), any(LocalDateTime.class));
 
-            then(memberFcmTokenRepository).should(times(1)).findByFcmToken(request.fcmToken());
-            then(memberFcmTokenRepository).should(never()).findByMemberAndDeviceIdentifier(any(Member.class), anyString());
-            then(memberFcmTokenRepository).should(never()).save(any(MemberFcmToken.class));
+            then(fcmTokenRepository).should(times(1)).findByFcmToken(request.fcmToken());
+            then(fcmTokenRepository).should(never()).findByMemberAndDeviceIdentifier(any(Member.class), anyString());
+            then(fcmTokenRepository).should(never()).save(any(FcmToken.class));
         }
 
         @Test
@@ -79,26 +80,26 @@ class MemberFcmTokenServiceTest {
             // given
             Long memberId = 1L;
             Member member = TestUtils.createEntity(Member.class, Map.of("id", memberId));
-            MemberFcmTokenRequest request = MemberFcmTokenRequest.builder()
+            FcmTokenRequest request = FcmTokenRequest.builder()
                     .fcmToken("new-fcm-token")
                     .deviceType("IOS")
                     .deviceIdentifier("device-123")
                     .build();
-            MemberFcmToken activeToken = mock(MemberFcmToken.class);
+            FcmToken activeToken = mock(FcmToken.class);
 
             given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-            given(memberFcmTokenRepository.findByFcmToken(request.fcmToken())).willReturn(Optional.empty());
-            given(memberFcmTokenRepository.findByMemberAndDeviceIdentifier(member, request.deviceIdentifier())).willReturn(Optional.of(activeToken));
+            given(fcmTokenRepository.findByFcmToken(request.fcmToken())).willReturn(Optional.empty());
+            given(fcmTokenRepository.findByMemberAndDeviceIdentifier(member, request.deviceIdentifier())).willReturn(Optional.of(activeToken));
 
             // when
-            memberFcmTokenService.upsertTokenForMember(request, memberId);
+            fcmTokenService.upsertTokenForMember(request, memberId);
 
             // then
             then(activeToken).should(times(1)).updateFcmToken(eq(request.fcmToken()), any(LocalDateTime.class));
 
-            then(memberFcmTokenRepository).should(times(1)).findByFcmToken(request.fcmToken());
-            then(memberFcmTokenRepository).should(times(1)).findByMemberAndDeviceIdentifier(member, request.deviceIdentifier());
-            then(memberFcmTokenRepository).should(never()).save(any(MemberFcmToken.class));
+            then(fcmTokenRepository).should(times(1)).findByFcmToken(request.fcmToken());
+            then(fcmTokenRepository).should(times(1)).findByMemberAndDeviceIdentifier(member, request.deviceIdentifier());
+            then(fcmTokenRepository).should(never()).save(any(FcmToken.class));
         }
 
         @Test
@@ -107,25 +108,25 @@ class MemberFcmTokenServiceTest {
             // given
             Long memberId = 1L;
             Member member = TestUtils.createEntity(Member.class, Map.of("id", memberId));
-            MemberFcmTokenRequest request = MemberFcmTokenRequest.builder()
+            FcmTokenRequest request = FcmTokenRequest.builder()
                     .fcmToken("fresh-fcm-token")
                     .deviceType("ANDROID")
                     .deviceIdentifier("device-123")
                     .build();
 
             given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-            given(memberFcmTokenRepository.findByFcmToken(request.fcmToken())).willReturn(Optional.empty());
-            given(memberFcmTokenRepository.findByMemberAndDeviceIdentifier(member, request.deviceIdentifier())).willReturn(Optional.empty());
-            given(memberFcmTokenRepository.save(any(MemberFcmToken.class))).willAnswer(invocation -> invocation.getArgument(0));
+            given(fcmTokenRepository.findByFcmToken(request.fcmToken())).willReturn(Optional.empty());
+            given(fcmTokenRepository.findByMemberAndDeviceIdentifier(member, request.deviceIdentifier())).willReturn(Optional.empty());
+            given(fcmTokenRepository.save(any(FcmToken.class))).willAnswer(invocation -> invocation.getArgument(0));
 
             // when
-            memberFcmTokenService.upsertTokenForMember(request, memberId);
+            fcmTokenService.upsertTokenForMember(request, memberId);
 
             // then
-            ArgumentCaptor<MemberFcmToken> tokenCaptor = ArgumentCaptor.forClass(MemberFcmToken.class);
-            then(memberFcmTokenRepository).should(times(1)).save(tokenCaptor.capture());
+            ArgumentCaptor<FcmToken> tokenCaptor = ArgumentCaptor.forClass(FcmToken.class);
+            then(fcmTokenRepository).should(times(1)).save(tokenCaptor.capture());
 
-            MemberFcmToken savedToken = tokenCaptor.getValue();
+            FcmToken savedToken = tokenCaptor.getValue();
             assertThat(savedToken.getMember()).isEqualTo(member);
             assertThat(savedToken.getFcmToken()).isEqualTo(request.fcmToken());
             assertThat(savedToken.getDeviceType()).isEqualTo(request.deviceType());
@@ -138,7 +139,7 @@ class MemberFcmTokenServiceTest {
         void upsertTokenForMember_thenMemberNotFound_throwsException() {
             // given
             Long memberId = 99L;
-            MemberFcmTokenRequest request = MemberFcmTokenRequest.builder()
+            FcmTokenRequest request = FcmTokenRequest.builder()
                     .fcmToken("sample-fcm-token")
                     .deviceType("ANDROID")
                     .deviceIdentifier("device-123")
@@ -147,13 +148,13 @@ class MemberFcmTokenServiceTest {
             given(memberRepository.findById(memberId)).willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> memberFcmTokenService.upsertTokenForMember(request, memberId))
+            assertThatThrownBy(() -> fcmTokenService.upsertTokenForMember(request, memberId))
                     .isInstanceOf(GlobalException.class)
                     .hasMessage(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
 
-            then(memberFcmTokenRepository).should(never()).findByFcmToken(anyString());
-            then(memberFcmTokenRepository).should(never()).findByMemberAndDeviceIdentifier(any(Member.class), anyString());
-            then(memberFcmTokenRepository).should(never()).save(any(MemberFcmToken.class));
+            then(fcmTokenRepository).should(never()).findByFcmToken(anyString());
+            then(fcmTokenRepository).should(never()).findByMemberAndDeviceIdentifier(any(Member.class), anyString());
+            then(fcmTokenRepository).should(never()).save(any(FcmToken.class));
         }
     }
 
@@ -166,14 +167,14 @@ class MemberFcmTokenServiceTest {
         void updateLastUsedAt_success_tokenExists() {
             // given
             String fcmToken = "existing-token";
-            MemberFcmToken memberFcmToken = mock(MemberFcmToken.class);
-            given(memberFcmTokenRepository.findByFcmToken(fcmToken)).willReturn(Optional.of(memberFcmToken));
+            FcmToken memberFcmToken = mock(FcmToken.class);
+            given(fcmTokenRepository.findByFcmToken(fcmToken)).willReturn(Optional.of(memberFcmToken));
 
             // when
-            memberFcmTokenService.updateLastUsedAt(fcmToken);
+            fcmTokenService.updateLastUsedAt(fcmToken);
 
             // then
-            then(memberFcmTokenRepository).should(times(1)).findByFcmToken(fcmToken);
+            then(fcmTokenRepository).should(times(1)).findByFcmToken(fcmToken);
             then(memberFcmToken).should(times(1)).updateLastUsedAt(any(LocalDateTime.class));
         }
 
@@ -182,14 +183,14 @@ class MemberFcmTokenServiceTest {
         void updateLastUsedAt_fail_tokenNotFound() {
             // given
             String fcmToken = "missing-token";
-            given(memberFcmTokenRepository.findByFcmToken(fcmToken)).willReturn(Optional.empty());
+            given(fcmTokenRepository.findByFcmToken(fcmToken)).willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> memberFcmTokenService.updateLastUsedAt(fcmToken))
+            assertThatThrownBy(() -> fcmTokenService.updateLastUsedAt(fcmToken))
                     .isInstanceOf(GlobalException.class)
                     .hasMessage(MemberErrorCode.MEMBER_FCM_TOKEN_NOT_FOUND.getMessage());
 
-            then(memberFcmTokenRepository).should(times(1)).findByFcmToken(fcmToken);
+            then(fcmTokenRepository).should(times(1)).findByFcmToken(fcmToken);
         }
     }
 
@@ -202,15 +203,15 @@ class MemberFcmTokenServiceTest {
         void deleteToken_success_tokenExists() {
             // given
             String fcmToken = "removable-token";
-            MemberFcmToken memberFcmToken = mock(MemberFcmToken.class);
-            given(memberFcmTokenRepository.findByFcmToken(fcmToken)).willReturn(Optional.of(memberFcmToken));
+            FcmToken memberFcmToken = mock(FcmToken.class);
+            given(fcmTokenRepository.findByFcmToken(fcmToken)).willReturn(Optional.of(memberFcmToken));
 
             // when
-            memberFcmTokenService.deleteToken(fcmToken);
+            fcmTokenService.deleteToken(fcmToken);
 
             // then
-            then(memberFcmTokenRepository).should(times(1)).findByFcmToken(fcmToken);
-            then(memberFcmTokenRepository).should(times(1)).delete(memberFcmToken);
+            then(fcmTokenRepository).should(times(1)).findByFcmToken(fcmToken);
+            then(fcmTokenRepository).should(times(1)).delete(memberFcmToken);
         }
 
         @Test
@@ -218,15 +219,15 @@ class MemberFcmTokenServiceTest {
         void deleteToken_fail_tokenNotFound() {
             // given
             String fcmToken = "invalid-token";
-            given(memberFcmTokenRepository.findByFcmToken(fcmToken)).willReturn(Optional.empty());
+            given(fcmTokenRepository.findByFcmToken(fcmToken)).willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> memberFcmTokenService.deleteToken(fcmToken))
+            assertThatThrownBy(() -> fcmTokenService.deleteToken(fcmToken))
                     .isInstanceOf(GlobalException.class)
                     .hasMessage(MemberErrorCode.MEMBER_FCM_TOKEN_NOT_FOUND.getMessage());
 
-            then(memberFcmTokenRepository).should(times(1)).findByFcmToken(fcmToken);
-            then(memberFcmTokenRepository).should(never()).delete(any(MemberFcmToken.class));
+            then(fcmTokenRepository).should(times(1)).findByFcmToken(fcmToken);
+            then(fcmTokenRepository).should(never()).delete(any(FcmToken.class));
         }
     }
 
@@ -240,15 +241,15 @@ class MemberFcmTokenServiceTest {
             // given
             Set<String> successTokens = Set.of("success-1", "success-2");
             Set<String> failureTokens = Set.of("failure-1");
-            given(memberFcmTokenRepository.updateLastUsedAtByFcmTokenIn(anySet(), any(LocalDateTime.class))).willReturn(successTokens.size());
-            given(memberFcmTokenRepository.deleteByFcmTokenIn(failureTokens)).willReturn(failureTokens.size());
+            given(fcmTokenRepository.updateLastUsedAtByFcmTokenIn(anySet(), any(LocalDateTime.class))).willReturn(successTokens.size());
+            given(fcmTokenRepository.deleteByFcmTokenIn(failureTokens)).willReturn(failureTokens.size());
 
             // when
-            memberFcmTokenService.updateTokensAfterSend(successTokens, failureTokens);
+            fcmTokenService.updateTokensAfterSend(successTokens, failureTokens);
 
             // then
-            then(memberFcmTokenRepository).should(times(1)).updateLastUsedAtByFcmTokenIn(eq(successTokens), any(LocalDateTime.class));
-            then(memberFcmTokenRepository).should(times(1)).deleteByFcmTokenIn(eq(failureTokens));
+            then(fcmTokenRepository).should(times(1)).updateLastUsedAtByFcmTokenIn(eq(successTokens), any(LocalDateTime.class));
+            then(fcmTokenRepository).should(times(1)).deleteByFcmTokenIn(eq(failureTokens));
         }
 
         @Test
@@ -259,11 +260,11 @@ class MemberFcmTokenServiceTest {
             Set<String> failureTokens = Set.of();
 
             // when
-            memberFcmTokenService.updateTokensAfterSend(successTokens, failureTokens);
+            fcmTokenService.updateTokensAfterSend(successTokens, failureTokens);
 
             // then
-            then(memberFcmTokenRepository).should(never()).updateLastUsedAtByFcmTokenIn(anySet(), any(LocalDateTime.class));
-            then(memberFcmTokenRepository).should(never()).deleteByFcmTokenIn(anySet());
+            then(fcmTokenRepository).should(never()).updateLastUsedAtByFcmTokenIn(anySet(), any(LocalDateTime.class));
+            then(fcmTokenRepository).should(never()).deleteByFcmTokenIn(anySet());
         }
     }
 }

--- a/src/test/java/com/sparta/couponpop/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/notification/service/NotificationServiceTest.java
@@ -2,11 +2,11 @@ package com.sparta.couponpop.domain.notification.service;
 
 import com.sparta.couponpop.common.exception.GlobalException;
 import com.sparta.couponpop.common.fcm.service.FcmSendService;
+import com.sparta.couponpop.domain.fcmtoken.entity.FcmToken;
+import com.sparta.couponpop.domain.fcmtoken.repository.FcmTokenRepository;
 import com.sparta.couponpop.domain.member.entity.Member;
-import com.sparta.couponpop.domain.member.entity.MemberFcmToken;
 import com.sparta.couponpop.domain.member.enums.MemberType;
 import com.sparta.couponpop.domain.member.exception.MemberErrorCode;
-import com.sparta.couponpop.domain.member.repository.MemberFcmTokenRepository;
 import com.sparta.couponpop.domain.member.repository.MemberRepository;
 import com.sparta.couponpop.domain.notification.constants.NotificationTemplates;
 import com.sparta.couponpop.domain.notification.dto.payload.CouponIssuedNotificationPayload;
@@ -42,7 +42,7 @@ class NotificationServiceTest {
     private MemberRepository memberRepository;
 
     @Mock
-    private MemberFcmTokenRepository memberFcmTokenRepository;
+    private FcmTokenRepository fcmTokenRepository;
 
     @Mock
     private FcmSendService fcmSendService;
@@ -84,7 +84,7 @@ class NotificationServiceTest {
                     .isInstanceOf(GlobalException.class)
                     .hasMessage(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
 
-            verifyNoInteractions(memberFcmTokenRepository, fcmSendService);
+            verifyNoInteractions(fcmTokenRepository, fcmSendService);
         }
 
         @Test
@@ -94,7 +94,7 @@ class NotificationServiceTest {
             CouponUsedNotificationPayload payload = CouponUsedNotificationPayload.of(1L, "오픈 기념 쿠폰", "스타벅스 강남역점");
 
             given(memberRepository.findById(payload.customerId())).willReturn(Optional.of(member));
-            given(memberFcmTokenRepository.findByMemberAndNotificationEnabledIsTrue(member)).willReturn(List.of());
+            given(fcmTokenRepository.findByMemberAndNotificationEnabledIsTrue(member)).willReturn(List.of());
 
             // when
             notificationService.send(payload);
@@ -107,15 +107,15 @@ class NotificationServiceTest {
         @DisplayName("활성화된 토큰에 알림을 전송한다")
         void notifyCustomerCouponUsed_success_sendNotification() {
             // given
-            MemberFcmToken token1 = MemberFcmToken.of(member, "token-1", "ANDROID", "device-1", true, LocalDateTime.now());
-            MemberFcmToken token2 = MemberFcmToken.of(member, "token-2", "IOS", "device-2", true, LocalDateTime.now());
-            MemberFcmToken token3 = MemberFcmToken.of(member, "token-3", "ANDROID", "device-3", true, LocalDateTime.now());
-            MemberFcmToken duplicateToken = MemberFcmToken.of(member, "token-1", "ANDROID", "device-4", true, LocalDateTime.now()); // 중복 토큰
+            FcmToken token1 = FcmToken.of(member, "token-1", "ANDROID", "device-1", true, LocalDateTime.now());
+            FcmToken token2 = FcmToken.of(member, "token-2", "IOS", "device-2", true, LocalDateTime.now());
+            FcmToken token3 = FcmToken.of(member, "token-3", "ANDROID", "device-3", true, LocalDateTime.now());
+            FcmToken duplicateToken = FcmToken.of(member, "token-1", "ANDROID", "device-4", true, LocalDateTime.now()); // 중복 토큰
 
             CouponUsedNotificationPayload payload = CouponUsedNotificationPayload.of(1L, "오픈 기념 쿠폰", "스타벅스 강남역점");
 
             given(memberRepository.findById(payload.customerId())).willReturn(Optional.of(member));
-            given(memberFcmTokenRepository.findByMemberAndNotificationEnabledIsTrue(member)).willReturn(List.of(token1, token2, token3, duplicateToken));
+            given(fcmTokenRepository.findByMemberAndNotificationEnabledIsTrue(member)).willReturn(List.of(token1, token2, token3, duplicateToken));
             given(fcmSendService.sendNotification(anyLong(), anyString(), anyString(), anyString())).willReturn(CompletableFuture.completedFuture(null));
 
             String expectedTitle = NotificationTemplates.COUPON_USED_TITLE.formatted(payload.couponName());
@@ -178,7 +178,7 @@ class NotificationServiceTest {
                     .isInstanceOf(GlobalException.class)
                     .hasMessage(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
 
-            verifyNoInteractions(memberFcmTokenRepository, fcmSendService);
+            verifyNoInteractions(fcmTokenRepository, fcmSendService);
         }
 
         @Test
@@ -188,7 +188,7 @@ class NotificationServiceTest {
             CouponIssuedNotificationPayload payload = CouponIssuedNotificationPayload.of(2L, "오픈 기념 쿠폰", 30, 15);
 
             given(memberRepository.findById(payload.ownerId())).willReturn(Optional.of(member));
-            given(memberFcmTokenRepository.findByMemberAndNotificationEnabledIsTrue(member)).willReturn(List.of());
+            given(fcmTokenRepository.findByMemberAndNotificationEnabledIsTrue(member)).willReturn(List.of());
 
             // when
             notificationService.send(payload);
@@ -201,15 +201,15 @@ class NotificationServiceTest {
         @DisplayName("활성화된 토큰에 알림을 전송한다")
         void notifyOwnerCouponIssued_success_sendNotification() {
             // given
-            MemberFcmToken token1 = MemberFcmToken.of(member, "token-1", "ANDROID", "device-1", true, LocalDateTime.now());
-            MemberFcmToken token2 = MemberFcmToken.of(member, "token-2", "IOS", "device-2", true, LocalDateTime.now());
-            MemberFcmToken token3 = MemberFcmToken.of(member, "token-3", "ANDROID", "device-3", true, LocalDateTime.now());
-            MemberFcmToken duplicateToken = MemberFcmToken.of(member, "token-1", "ANDROID", "device-4", true, LocalDateTime.now()); // 중복 토큰
+            FcmToken token1 = FcmToken.of(member, "token-1", "ANDROID", "device-1", true, LocalDateTime.now());
+            FcmToken token2 = FcmToken.of(member, "token-2", "IOS", "device-2", true, LocalDateTime.now());
+            FcmToken token3 = FcmToken.of(member, "token-3", "ANDROID", "device-3", true, LocalDateTime.now());
+            FcmToken duplicateToken = FcmToken.of(member, "token-1", "ANDROID", "device-4", true, LocalDateTime.now()); // 중복 토큰
 
             CouponIssuedNotificationPayload payload = CouponIssuedNotificationPayload.of(2L, "오픈 기념 쿠폰", 30, 15);
 
             given(memberRepository.findById(payload.ownerId())).willReturn(Optional.of(member));
-            given(memberFcmTokenRepository.findByMemberAndNotificationEnabledIsTrue(member)).willReturn(List.of(token1, token2, token3, duplicateToken));
+            given(fcmTokenRepository.findByMemberAndNotificationEnabledIsTrue(member)).willReturn(List.of(token1, token2, token3, duplicateToken));
             given(fcmSendService.sendNotification(anyLong(), anyString(), anyString(), anyString())).willReturn(CompletableFuture.completedFuture(null));
 
             String expectedTitle = NotificationTemplates.COUPON_ISSUED_TITLE.formatted(payload.couponName());
@@ -243,11 +243,11 @@ class NotificationServiceTest {
         @DisplayName("FCM 전송 중 예외가 발생해도 예외를 전파하지 않는다")
         void notifyOwnerCouponIssued_success_ignoreMessagingException() {
             // given
-            MemberFcmToken token = MemberFcmToken.of(member, "token-1", "ANDROID", "device-1", true, LocalDateTime.now());
+            FcmToken token = FcmToken.of(member, "token-1", "ANDROID", "device-1", true, LocalDateTime.now());
             CouponIssuedNotificationPayload payload = CouponIssuedNotificationPayload.of(2L, "오픈 기념 쿠폰", 30, 15);
 
             given(memberRepository.findById(payload.ownerId())).willReturn(Optional.of(member));
-            given(memberFcmTokenRepository.findByMemberAndNotificationEnabledIsTrue(member)).willReturn(List.of(token));
+            given(fcmTokenRepository.findByMemberAndNotificationEnabledIsTrue(member)).willReturn(List.of(token));
 
             CompletableFuture<Void> failedFuture = new CompletableFuture<>();
             failedFuture.completeExceptionally(new RuntimeException("전송 실패"));


### PR DESCRIPTION
## 🔗 **연관된 이슈**
> close #이슈번호
- close #166 

<br>

## 📝 **작업 내용**

- 기존 코드들을 member -> fcmtoken 패키지로 이동
- 파일명 앞에 Member 제거
- flyway 테이블명 변경 sql문 작성

<br>

## 📸 **스크린샷 (선택)**

<br>
