### PR TITLE
refactor: member, auth 도메인 Repository 직접 의존 제거

### DIFF
--- a/src/main/java/com/sparta/couponpop/common/dto/fcmtoken/request/FcmTokenExpireRequest.java
+++ b/src/main/java/com/sparta/couponpop/common/dto/fcmtoken/request/FcmTokenExpireRequest.java
@@ -1,0 +1,9 @@
+package com.sparta.couponpop.common.dto.fcmtoken.request;
+
+public record FcmTokenExpireRequest(
+        String fcmToken
+) {
+    public static FcmTokenExpireRequest from(String fcmToken) {
+        return new FcmTokenExpireRequest(fcmToken);
+    }
+}

--- a/src/main/java/com/sparta/couponpop/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/couponpop/domain/auth/controller/AuthController.java
@@ -43,10 +43,9 @@ public class AuthController {
     @PostMapping("/logout")
     @PreAuthorize("isAuthenticated()") // auth는 모두 접근가능하므로, 로그아웃은 인증된 사용자만 접근 가능
     public ResponseEntity<ApiResponse<Void>> logout(@RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader,
-                                                    @CurrentMember AuthMember authMember,
                                                     @Valid @RequestBody LogoutRequest logoutRequest) {
 
-        authService.logout(authorizationHeader, logoutRequest, authMember);
+        authService.logout(authorizationHeader, logoutRequest);
         return ApiResponse.noContent();
     }
 

--- a/src/main/java/com/sparta/couponpop/domain/auth/service/AuthService.java
+++ b/src/main/java/com/sparta/couponpop/domain/auth/service/AuthService.java
@@ -11,7 +11,7 @@ import com.sparta.couponpop.domain.auth.dto.response.LoginResponse;
 import com.sparta.couponpop.domain.auth.dto.response.SignUpResponse;
 import com.sparta.couponpop.domain.auth.event.TokenBlacklistEvent;
 import com.sparta.couponpop.domain.auth.exception.AuthErrorCode;
-import com.sparta.couponpop.domain.fcmtoken.repository.FcmTokenRepository;
+import com.sparta.couponpop.domain.fcmtoken.service.FcmTokenInternalService;
 import com.sparta.couponpop.domain.member.entity.Member;
 import com.sparta.couponpop.domain.member.exception.MemberErrorCode;
 import com.sparta.couponpop.domain.member.repository.MemberRepository;
@@ -34,8 +34,9 @@ public class AuthService {
     private final JwtProvider jwtProvider;
 
     private final MemberRepository memberRepository;
-    private final FcmTokenRepository fcmTokenRepository;
+
     private final TokenBlacklistService tokenBlacklistService;
+    private final FcmTokenInternalService fcmTokenInternalService;
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
@@ -94,7 +95,7 @@ public class AuthService {
         long expirationMillis = jwtProvider.getExpirationMillis(resolvedToken);
 
         blacklistToken(resolvedToken, expirationMillis);
-        expireFcmToken(authMember.id(), logoutRequest.fcmToken());
+        fcmTokenInternalService.expireFcmToken(logoutRequest.fcmToken());
     }
 
     // 회원 탈퇴가 되면 토큰만료 이벤트 발행, 회원탈퇴가 되지 않으면 롤백
@@ -108,7 +109,7 @@ public class AuthService {
                 .orElseThrow(() -> new GlobalException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         memberToWithdraw.withdraw();
-        expireFcmToken(memberToWithdraw.getId(), withdrawRequest.fcmToken());
+        fcmTokenInternalService.expireFcmToken(withdrawRequest.fcmToken());
         publishBlacklistTokenEvent(resolvedToken, expirationMillis);
     }
 
@@ -123,14 +124,6 @@ public class AuthService {
         TokenBlacklistEvent event = TokenBlacklistEvent.of(token, expirationMillis);
         eventPublisher.publishEvent(event);
         log.debug("[publishBlacklistTokenEvent] 토큰 블랙리스트 이벤트 발행 - token={}", token);
-    }
-
-    // FCM 토큰 삭제는 실패하더라도 전체 작업이 롤백되지는 않도록 ifPresent 사용
-    private void expireFcmToken(Long memberId, String fcmToken) {
-
-        fcmTokenRepository
-                .findByMemberIdAndFcmToken(memberId, fcmToken)
-                .ifPresent(fcmTokenRepository::delete);
     }
 
     private String extractToken(String authorizationHeader) {

--- a/src/main/java/com/sparta/couponpop/domain/auth/service/AuthService.java
+++ b/src/main/java/com/sparta/couponpop/domain/auth/service/AuthService.java
@@ -1,5 +1,6 @@
 package com.sparta.couponpop.domain.auth.service;
 
+import com.sparta.couponpop.common.dto.fcmtoken.request.FcmTokenExpireRequest;
 import com.sparta.couponpop.common.exception.GlobalException;
 import com.sparta.couponpop.common.security.JwtProvider;
 import com.sparta.couponpop.common.security.dto.AuthMember;
@@ -89,13 +90,13 @@ public class AuthService {
     // 트랜잭션은 DB 작업(FcmToken 삭제)만 보장하며,
     // Redis 블랙리스트 작업은 별도 (분산 트랜잭션 고려하지 않음)
     @Transactional
-    public void logout(String authorizationHeader, LogoutRequest logoutRequest, AuthMember authMember) {
+    public void logout(String authorizationHeader, LogoutRequest logoutRequest) {
 
         String resolvedToken = extractToken(authorizationHeader);
         long expirationMillis = jwtProvider.getExpirationMillis(resolvedToken);
 
         blacklistToken(resolvedToken, expirationMillis);
-        fcmTokenInternalService.expireFcmToken(logoutRequest.fcmToken());
+        fcmTokenInternalService.expireFcmToken(FcmTokenExpireRequest.from(logoutRequest.fcmToken()));
     }
 
     // 회원 탈퇴가 되면 토큰만료 이벤트 발행, 회원탈퇴가 되지 않으면 롤백
@@ -109,7 +110,7 @@ public class AuthService {
                 .orElseThrow(() -> new GlobalException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         memberToWithdraw.withdraw();
-        fcmTokenInternalService.expireFcmToken(withdrawRequest.fcmToken());
+        fcmTokenInternalService.expireFcmToken(FcmTokenExpireRequest.from(withdrawRequest.fcmToken()));
         publishBlacklistTokenEvent(resolvedToken, expirationMillis);
     }
 

--- a/src/main/java/com/sparta/couponpop/domain/fcmtoken/service/FcmTokenInternalService.java
+++ b/src/main/java/com/sparta/couponpop/domain/fcmtoken/service/FcmTokenInternalService.java
@@ -1,6 +1,8 @@
 package com.sparta.couponpop.domain.fcmtoken.service;
 
+import com.sparta.couponpop.common.dto.fcmtoken.request.FcmTokenExpireRequest;
+
 public interface FcmTokenInternalService {
-    
-    void expireFcmToken(String fcmToken);
+
+    void expireFcmToken(FcmTokenExpireRequest fcmTokenExpireRequest);
 }

--- a/src/main/java/com/sparta/couponpop/domain/fcmtoken/service/FcmTokenInternalService.java
+++ b/src/main/java/com/sparta/couponpop/domain/fcmtoken/service/FcmTokenInternalService.java
@@ -1,0 +1,6 @@
+package com.sparta.couponpop.domain.fcmtoken.service;
+
+public interface FcmTokenInternalService {
+    
+    void expireFcmToken(String fcmToken);
+}

--- a/src/main/java/com/sparta/couponpop/domain/fcmtoken/service/FcmTokenInternalServiceImpl.java
+++ b/src/main/java/com/sparta/couponpop/domain/fcmtoken/service/FcmTokenInternalServiceImpl.java
@@ -1,0 +1,26 @@
+package com.sparta.couponpop.domain.fcmtoken.service;
+
+import com.sparta.couponpop.domain.fcmtoken.repository.FcmTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FcmTokenInternalServiceImpl implements FcmTokenInternalService {
+
+    private final FcmTokenRepository fcmTokenRepository;
+
+    /**
+     * TODO: Member Service의 로그아웃 API, 회원탈퇴 API 사용 필요
+     * memberId는 authMember로 부터 획득
+     * EDA 적용 가능
+     */
+    @Override
+    public void expireFcmToken(String fcmToken) {
+
+        // 기존 구현 메서드
+//        fcmTokenRepository
+//                .findByMemberIdAndFcmToken(memberId, fcmToken)
+//                .ifPresent(fcmTokenRepository::delete);
+    }
+}

--- a/src/main/java/com/sparta/couponpop/domain/fcmtoken/service/FcmTokenInternalServiceImpl.java
+++ b/src/main/java/com/sparta/couponpop/domain/fcmtoken/service/FcmTokenInternalServiceImpl.java
@@ -1,5 +1,6 @@
 package com.sparta.couponpop.domain.fcmtoken.service;
 
+import com.sparta.couponpop.common.dto.fcmtoken.request.FcmTokenExpireRequest;
 import com.sparta.couponpop.domain.fcmtoken.repository.FcmTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,11 +17,11 @@ public class FcmTokenInternalServiceImpl implements FcmTokenInternalService {
      * EDA 적용 가능
      */
     @Override
-    public void expireFcmToken(String fcmToken) {
+    public void expireFcmToken(FcmTokenExpireRequest fcmTokenExpireRequest) {
 
         // 기존 구현 메서드
 //        fcmTokenRepository
-//                .findByMemberIdAndFcmToken(memberId, fcmToken)
+//                .findByMemberIdAndFcmToken(memberId, fcmTokenExpireRequest.fcmToken())
 //                .ifPresent(fcmTokenRepository::delete);
     }
 }

--- a/src/test/java/com/sparta/couponpop/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/auth/controller/AuthControllerTest.java
@@ -297,7 +297,7 @@ class AuthControllerTest {
         LogoutRequest requestDto = new LogoutRequest("testFcmToken");
 
         // authService.logout()은 void를 반환
-        doNothing().when(authService).logout(anyString(), any(LogoutRequest.class), any(AuthMember.class));
+        doNothing().when(authService).logout(anyString(), any(LogoutRequest.class));
 
         // when
         ResultActions resultActions = mockMvc.perform(

--- a/src/test/java/com/sparta/couponpop/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/auth/service/AuthServiceTest.java
@@ -1,5 +1,6 @@
 package com.sparta.couponpop.domain.auth.service;
 
+import com.sparta.couponpop.common.dto.fcmtoken.request.FcmTokenExpireRequest;
 import com.sparta.couponpop.common.exception.GlobalException;
 import com.sparta.couponpop.common.security.JwtProvider;
 import com.sparta.couponpop.common.security.dto.AuthMember;
@@ -233,10 +234,10 @@ class AuthServiceTest {
             given(jwtProvider.resolveToken(testAuthorizationHeader)).willReturn(testToken);
             given(jwtProvider.getExpirationMillis(testToken)).willReturn(testExpirationMillis);
 
-            willDoNothing().given(fcmTokenInternalService).expireFcmToken(testLogoutRequest.fcmToken());
+            willDoNothing().given(fcmTokenInternalService).expireFcmToken(FcmTokenExpireRequest.from(testLogoutRequest.fcmToken()));
 
             // when
-            authService.logout(testAuthorizationHeader, testLogoutRequest, testAuthMember);
+            authService.logout(testAuthorizationHeader, testLogoutRequest);
 
             // then
             // 1. JWT 검증
@@ -245,7 +246,7 @@ class AuthServiceTest {
             verify(tokenBlacklistService).blacklistToken(testToken, testExpirationMillis);
 
             // 2. FCM Token 검증
-            verify(fcmTokenInternalService).expireFcmToken(testLogoutRequest.fcmToken());
+            verify(fcmTokenInternalService).expireFcmToken(FcmTokenExpireRequest.from(testLogoutRequest.fcmToken()));
         }
 
         @Test
@@ -259,11 +260,11 @@ class AuthServiceTest {
 
             // when & then
             GlobalException exception = assertThrows(GlobalException.class, () -> {
-                authService.logout(testAuthorizationHeader, testLogoutRequest, testAuthMember);
+                authService.logout(testAuthorizationHeader, testLogoutRequest);
             });
 
             assertThat(exception.getErrorCode()).isEqualTo(AuthErrorCode.INVALID_TOKEN);
-            verify(fcmTokenInternalService, never()).expireFcmToken(anyString());
+            verify(fcmTokenInternalService, never()).expireFcmToken(FcmTokenExpireRequest.from(anyString()));
         }
 
         @Test
@@ -277,10 +278,10 @@ class AuthServiceTest {
             given(jwtProvider.resolveToken(testAuthorizationHeader)).willReturn(testToken);
             given(jwtProvider.getExpirationMillis(testToken)).willReturn(testExpirationMillis);
 
-            willDoNothing().given(fcmTokenInternalService).expireFcmToken(testLogoutRequest.fcmToken());
+            willDoNothing().given(fcmTokenInternalService).expireFcmToken(FcmTokenExpireRequest.from(testLogoutRequest.fcmToken()));
 
             // when
-            authService.logout(testAuthorizationHeader, testLogoutRequest, testAuthMember);
+            authService.logout(testAuthorizationHeader, testLogoutRequest);
 
             // then
             // 1. JWT 검증
@@ -289,7 +290,7 @@ class AuthServiceTest {
             verify(tokenBlacklistService).blacklistToken(testToken, testExpirationMillis);
 
             // 2. FCM Token 검증
-            verify(fcmTokenInternalService).expireFcmToken(testLogoutRequest.fcmToken());
+            verify(fcmTokenInternalService).expireFcmToken(FcmTokenExpireRequest.from(testLogoutRequest.fcmToken()));
         }
     }
 
@@ -321,7 +322,7 @@ class AuthServiceTest {
             given(jwtProvider.getExpirationMillis(testToken)).willReturn(testExpirationMillis);
 
             // FCM 토큰
-            willDoNothing().given(fcmTokenInternalService).expireFcmToken(testWithdrawRequest.fcmToken());
+            willDoNothing().given(fcmTokenInternalService).expireFcmToken(FcmTokenExpireRequest.from(testWithdrawRequest.fcmToken()));
 
             // when
             authService.withdraw(testAuthorizationHeader, testAuthMember, testWithdrawRequest);
@@ -332,7 +333,7 @@ class AuthServiceTest {
                     .isBeforeOrEqualTo(LocalDateTime.now());
 
             // FCM 토큰
-            verify(fcmTokenInternalService).expireFcmToken(testWithdrawRequest.fcmToken());
+            verify(fcmTokenInternalService).expireFcmToken(FcmTokenExpireRequest.from(testWithdrawRequest.fcmToken()));
 
             // JWT
             verify(eventPublisher).publishEvent(any(TokenBlacklistEvent.class));

--- a/src/test/java/com/sparta/couponpop/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/sparta/couponpop/domain/auth/service/AuthServiceTest.java
@@ -12,12 +12,11 @@ import com.sparta.couponpop.domain.auth.dto.response.SignUpResponse;
 import com.sparta.couponpop.domain.auth.event.TokenBlacklistEvent;
 import com.sparta.couponpop.domain.auth.exception.AuthErrorCode;
 import com.sparta.couponpop.domain.fcmtoken.entity.FcmToken;
-import com.sparta.couponpop.domain.fcmtoken.repository.FcmTokenRepository;
+import com.sparta.couponpop.domain.fcmtoken.service.FcmTokenInternalService;
 import com.sparta.couponpop.domain.member.entity.Member;
 import com.sparta.couponpop.domain.member.enums.MemberType;
 import com.sparta.couponpop.domain.member.exception.MemberErrorCode;
 import com.sparta.couponpop.domain.member.repository.MemberRepository;
-import com.sparta.couponpop.domain.member.service.MemberService;
 import com.sparta.couponpop.utils.TestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -36,8 +35,10 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -51,16 +52,13 @@ class AuthServiceTest {
     private MemberRepository memberRepository;
 
     @Mock
-    private FcmTokenRepository fcmTokenRepository;
+    private FcmTokenInternalService fcmTokenInternalService;
 
     @Mock
     private JwtProvider jwtProvider;
 
     @Mock
     private TokenBlacklistService tokenBlacklistService;
-
-    @Mock
-    private MemberService memberService;
 
     @Mock
     private ApplicationEventPublisher eventPublisher;
@@ -232,13 +230,10 @@ class AuthServiceTest {
         void logoutSuccess() {
 
             // given
-            FcmToken mockFcmToken = TestUtils.createEntity(FcmToken.class, Map.of("fcmToken", "testFcmToken"));
-
             given(jwtProvider.resolveToken(testAuthorizationHeader)).willReturn(testToken);
             given(jwtProvider.getExpirationMillis(testToken)).willReturn(testExpirationMillis);
 
-            given(fcmTokenRepository.findByMemberIdAndFcmToken(testAuthMember.id(), testLogoutRequest.fcmToken()))
-                    .willReturn(Optional.of(mockFcmToken));
+            willDoNothing().given(fcmTokenInternalService).expireFcmToken(testLogoutRequest.fcmToken());
 
             // when
             authService.logout(testAuthorizationHeader, testLogoutRequest, testAuthMember);
@@ -250,8 +245,7 @@ class AuthServiceTest {
             verify(tokenBlacklistService).blacklistToken(testToken, testExpirationMillis);
 
             // 2. FCM Token 검증
-            verify(fcmTokenRepository).findByMemberIdAndFcmToken(testAuthMember.id(), testLogoutRequest.fcmToken());
-            verify(fcmTokenRepository).delete(mockFcmToken);
+            verify(fcmTokenInternalService).expireFcmToken(testLogoutRequest.fcmToken());
         }
 
         @Test
@@ -269,7 +263,7 @@ class AuthServiceTest {
             });
 
             assertThat(exception.getErrorCode()).isEqualTo(AuthErrorCode.INVALID_TOKEN);
-            verify(fcmTokenRepository, never()).findByMemberIdAndFcmToken(anyLong(), anyString());
+            verify(fcmTokenInternalService, never()).expireFcmToken(anyString());
         }
 
         @Test
@@ -283,8 +277,7 @@ class AuthServiceTest {
             given(jwtProvider.resolveToken(testAuthorizationHeader)).willReturn(testToken);
             given(jwtProvider.getExpirationMillis(testToken)).willReturn(testExpirationMillis);
 
-            given(fcmTokenRepository.findByMemberIdAndFcmToken(testAuthMember.id(), testLogoutRequest.fcmToken()))
-                    .willReturn(Optional.empty());
+            willDoNothing().given(fcmTokenInternalService).expireFcmToken(testLogoutRequest.fcmToken());
 
             // when
             authService.logout(testAuthorizationHeader, testLogoutRequest, testAuthMember);
@@ -296,7 +289,7 @@ class AuthServiceTest {
             verify(tokenBlacklistService).blacklistToken(testToken, testExpirationMillis);
 
             // 2. FCM Token 검증
-            verify(fcmTokenRepository).findByMemberIdAndFcmToken(testAuthMember.id(), testLogoutRequest.fcmToken());
+            verify(fcmTokenInternalService).expireFcmToken(testLogoutRequest.fcmToken());
         }
     }
 
@@ -319,7 +312,6 @@ class AuthServiceTest {
             ));
 
             WithdrawRequest testWithdrawRequest = new WithdrawRequest("testFcmToken");
-            FcmToken mockFcmToken = TestUtils.createEntity(FcmToken.class, Map.of("fcmToken", "testFcmToken"));
 
             // member 조회
             given(memberRepository.findById(testAuthMember.id())).willReturn(Optional.of(mockMember));
@@ -329,8 +321,7 @@ class AuthServiceTest {
             given(jwtProvider.getExpirationMillis(testToken)).willReturn(testExpirationMillis);
 
             // FCM 토큰
-            given(fcmTokenRepository.findByMemberIdAndFcmToken(testAuthMember.id(), testWithdrawRequest.fcmToken()))
-                    .willReturn(Optional.of(mockFcmToken));
+            willDoNothing().given(fcmTokenInternalService).expireFcmToken(testWithdrawRequest.fcmToken());
 
             // when
             authService.withdraw(testAuthorizationHeader, testAuthMember, testWithdrawRequest);
@@ -341,8 +332,7 @@ class AuthServiceTest {
                     .isBeforeOrEqualTo(LocalDateTime.now());
 
             // FCM 토큰
-            verify(fcmTokenRepository).findByMemberIdAndFcmToken(testAuthMember.id(), testWithdrawRequest.fcmToken());
-            verify(fcmTokenRepository).delete(mockFcmToken);
+            verify(fcmTokenInternalService).expireFcmToken(testWithdrawRequest.fcmToken());
 
             // JWT
             verify(eventPublisher).publishEvent(any(TokenBlacklistEvent.class));
@@ -367,7 +357,7 @@ class AuthServiceTest {
 
             assertThat(exception.getErrorCode()).isEqualTo(MemberErrorCode.MEMBER_NOT_FOUND);
 
-            verify(fcmTokenRepository, never()).delete(any());
+            verify(fcmTokenInternalService, never()).expireFcmToken(any());
             verify(eventPublisher, never()).publishEvent(any());
         }
     }


### PR DESCRIPTION
## 🔗 **연관된 이슈**
> close #이슈번호

<br>

- close #168 

## 📝 **작업 내용**

- MSA 전환 로드맵 Phase-1 MSA의 Member 서비스 애플리케이션 대상 수행
  - [x] AuthService내의 FcmTokenRepository 의존 제거
  - [x] FcmTokenInternalService 인터페이스 및 구현체에 필요한 메서드 TODO 정의
  - [x] 변경된 로직에 맞게 테스트 코드 수정

<br>

## 📸 **스크린샷 (선택)**

<br>
