### PR TITLE
feat: 내부용 Controller 작성, FcmToken 엔티티 필드 속성 추가

### DIFF
--- a/src/main/java/com/sparta/couponpop/domain/fcmtoken/controller/FcmTokenInternalController.java
+++ b/src/main/java/com/sparta/couponpop/domain/fcmtoken/controller/FcmTokenInternalController.java
@@ -1,0 +1,22 @@
+package com.sparta.couponpop.domain.fcmtoken.controller;
+
+import com.sparta.couponpop.domain.fcmtoken.service.FcmTokenInternalService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/internal")
+@RequiredArgsConstructor
+public class FcmTokenInternalController {
+
+    private final FcmTokenInternalService fcmTokenInternalService;
+
+    @PostMapping("/v1/fcm-token/expire")
+    public ResponseEntity<Void> expireFcmToken() {
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/sparta/couponpop/domain/fcmtoken/entity/FcmToken.java
+++ b/src/main/java/com/sparta/couponpop/domain/fcmtoken/entity/FcmToken.java
@@ -21,14 +21,19 @@ public class FcmToken extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private Long memberId;
 
+    @Column(nullable = false)
     private String fcmToken;
 
+    @Column(nullable = false, length = 32)
     private String deviceType;
 
+    @Column(nullable = false, length = 128)
     private String deviceIdentifier;
 
+    @Column(nullable = false)
     private boolean notificationEnabled;
 
     private LocalDateTime lastUsedAt;


### PR DESCRIPTION
## 🔗 **연관된 이슈**
> close #이슈번호
- close #180 

<br>

## 📝 **작업 내용**

- 토큰 만료 엔드포인트 작성 (`/internal/v1/fcm-token/expire`)
- FcmToken 엔티티에 필드 속성 추가

<br>

## 📸 **스크린샷 (선택)**

<br>
